### PR TITLE
Drop Linux header to unbreak on FreeBSD

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -16,7 +16,11 @@ CXXFLAGS += $(COMPFLAGS) -std=gnu++17
 
 LDFLAGS +=
 
-PKGS = wayland-client yaml-cpp libinput libudev
+ifeq (,$(filter-out DragonFly FreeBSD NetBSD OpenBSD,$(shell uname -s)))
+PKGS += epoll-shim libinotify
+endif
+
+PKGS += wayland-client yaml-cpp libinput libudev
 CFLAGS += $(foreach p,$(PKGS),$(shell pkg-config --cflags $(p)))
 CXXFLAGS += $(foreach p,$(PKGS),$(shell pkg-config --cflags $(p)))
 LDLIBS += $(foreach p,$(PKGS),$(shell pkg-config --libs $(p)))

--- a/config.mk
+++ b/config.mk
@@ -18,6 +18,7 @@ LDFLAGS +=
 
 PKGS = wayland-client yaml-cpp libinput libudev
 CFLAGS += $(foreach p,$(PKGS),$(shell pkg-config --cflags $(p)))
+CXXFLAGS += $(foreach p,$(PKGS),$(shell pkg-config --cflags $(p)))
 LDLIBS += $(foreach p,$(PKGS),$(shell pkg-config --libs $(p)))
 
 CC ?= gcc

--- a/src/log.c
+++ b/src/log.c
@@ -1,4 +1,3 @@
-#include <bits/types/struct_tm.h>
 #include <errno.h>
 #include <stdarg.h>
 #include <stdbool.h>


### PR DESCRIPTION
Leaving out the following for simplicity ([downstream](https://www.freshports.org/x11/way-displays) can [override/append](https://github.com/freebsd/freebsd-ports/blob/a7011e478978bdf10607e39066e2f7a6fa444cd4/x11/way-displays/Makefile#L25-L27)):
```diff
diff --git a/config.mk b/config.mk
index 87e1ecd..c6aebe2 100644
--- a/config.mk
+++ b/config.mk
@@ -18,10 +18,9 @@ COMPFLAGS = $(WFLAGS) $(OFLAGS)
 CFLAGS += $(COMPFLAGS) -std=gnu17
 CXXFLAGS += $(COMPFLAGS) -std=gnu++17
 
-LDFLAGS +=
+# If we have pkg-config try harder to pass correct flags
+CFLAGS += `pkg-config --cflags wayland-client 2>/dev/null || echo -isystem$(PREFIX)/include`
+CXXFLAGS += `pkg-config --cflags yaml-cpp 2>/dev/null`
+LDFLAGS += `pkg-config --libs epoll-shim libinotify 2>/dev/null` # BSD, ignore on Linux
 
 LDLIBS += -lwayland-client -lyaml-cpp -linput -ludev
-
-CC = gcc
-CXX = g++
-
```
