### PR TITLE
replace __pid_t with pid_t

### DIFF
--- a/inc/process.h
+++ b/inc/process.h
@@ -3,7 +3,7 @@
 
 #include <sys/types.h>
 
-__pid_t pid_active_server(void);
+pid_t pid_active_server(void);
 
 void pid_file_create(void);
 

--- a/src/process.c
+++ b/src/process.c
@@ -26,10 +26,10 @@ char *pid_path(void) {
 	return path;
 }
 
-__pid_t pid_active_server(void) {
+pid_t pid_active_server(void) {
 	static char pbuf[11];
 
-	__pid_t pid = 0;
+	pid_t pid = 0;
 
 	char *path = pid_path();
 
@@ -53,7 +53,7 @@ __pid_t pid_active_server(void) {
 void pid_file_create(void) {
 	char *path = pid_path();
 
-	__pid_t pid = pid_active_server();
+	pid_t pid = pid_active_server();
 	if (pid_active_server()) {
 		log_error("\nanother instance %d is running, exiting", pid);
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
compiling on alpine linux edge otherwise fails with:  

```
In file included from src/client.c:10:
inc/process.h:6:1: error: unknown type name '__pid_t'; did you mean 'pid_t'?
    6 | __pid_t pid_active_server(void);
      | ^~~~~~~
      | pid_t
gcc -O2 -pipe -fomit-frame-pointer -march=native -fstack-clash-protection -ftree-vectorize -pedantic -Wall -Wextra -Werror -Wno-unused-parameter -O3 -std=gnu17 -Wold-style-definition -Wstrict-prototypes     -O2 -pipe -fomit-frame-pointer -march=native -fstack-clash-protection -ftree-vectorize -Iinc -Ipro -D_GNU_SOURCE -DVERSION=\""1.5.0"\"  -c -o src/layout.o src/layout.c
make: *** [<builtin>: src/client.o] Error 1
make: *** Waiting for unfinished jobs....
In file included from src/displ.c:9:
inc/process.h:6:1: error: unknown type name '__pid_t'; did you mean 'pid_t'?
    6 | __pid_t pid_active_server(void);
      | ^~~~~~~
      | pid_t
make: *** [<builtin>: src/displ.o] Error 1
In file included from src/fds.c:17:
inc/process.h:6:1: error: unknown type name '__pid_t'; did you mean 'pid_t'?
    6 | __pid_t pid_active_server(void);
      | ^~~~~~~
      | pid_t
make: *** [<builtin>: src/fds.o] Error 1
```