### PR TITLE
don't walk over sun_path size limit in snprintf()

### DIFF
--- a/src/sockets.c
+++ b/src/sockets.c
@@ -87,7 +87,7 @@ ssize_t socket_write(int fd, char *data, size_t len) {
 void socket_path(struct sockaddr_un *addr) {
 	size_t sun_path_size = sizeof(addr->sun_path);
 
-	char name[sun_path_size];
+	char name[sun_path_size - 4];
 	if (getenv("XDG_VTNR")) {
 		snprintf(name, sizeof(name), "/way-displays.%s.sock", getenv("XDG_VTNR"));
 	} else {


### PR DESCRIPTION
otherwise building on ppc64le fails with:  

```
src/sockets.c: In function 'socket_path':
src/sockets.c:98:62: error: '%s' directive output may be truncated writing up to 107 bytes into a region of size 104 [-Werror=format-truncation=]
   98 |                 snprintf(addr->sun_path, sun_path_size, "/tmp%s", name);
      |                                                              ^~
src/sockets.c:98:17: note: 'snprintf' output between 5 and 112 bytes into a destination of size 108
   98 |                 snprintf(addr->sun_path, sun_path_size, "/tmp%s", name);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

this is caused by the "/tmp%s" format specifier:  
`snprintf(addr->sun_path, sun_path_size, "/tmp%s", name);`  
being 4 bytes longer than sun_path/sun_path_size (when added to the size of `name`), so make `name` shorter by 4 than the sun_path_size so it fits  

as an aside, i have no idea why this doesn't fail on any other arch. technically on all of them that is doing a size = size + 4, so they should all be truncated...