### PR TITLE
Warn if unable to discover laptop lid

### DIFF
--- a/src/lid.c
+++ b/src/lid.c
@@ -181,14 +181,17 @@ void lid_init(void) {
 		destroy_libinput_discovery(libinput_discovery);
 
 		if (!device_path) {
+			log_warn("No lid device was discovered; lid remains unitialized");
 			return;
 		}
 	} else {
+		log_warn("Unable to start libinput discovery for lid device");
 		return;
 	}
 
 	// monitor in a context with just the lid
 	if (!(libinput_monitor = create_libinput_monitor(device_path))) {
+		log_warn("Unable to create libinput monitor for lid device %s", device_path);
 		return;
 	}
 

--- a/src/lid.c
+++ b/src/lid.c
@@ -207,6 +207,9 @@ bool lid_is_closed(char *name) {
 	if (!name)
 		return false;
 
+	if (!lid)
+		return false;
+
 	const char *laptop_display_prefix;
 	if (cfg->laptop_display_prefix) {
 		laptop_display_prefix = cfg->laptop_display_prefix;

--- a/src/lid.c
+++ b/src/lid.c
@@ -181,7 +181,6 @@ void lid_init(void) {
 		destroy_libinput_discovery(libinput_discovery);
 
 		if (!device_path) {
-			log_warn("No lid device was discovered; lid remains unitialized");
 			return;
 		}
 	} else {


### PR DESCRIPTION
Fix a segfault where (due to misconfiguration) way-displays cannot create a libinput monitor for the laptop lid, in my case because my user account was missing membership of the `input` group. When this is the case, `lid_init` exits early, without initializing the `lid` object, and `lid_is_closed` will segfault when trying to access `lid->closed`.