### PR TITLE
#45 add ROOT_ETC so that distros like nix may override /etc

### DIFF
--- a/.ccls
+++ b/.ccls
@@ -5,6 +5,7 @@ clang
 
 -D_GNU_SOURCE
 -DVERSION="DUMMY"
+-DROOT_ETC="/etc"
 
 -pedantic
 -Wall

--- a/config.mk
+++ b/config.mk
@@ -2,10 +2,11 @@ VERSION ?= "1.5.4-SNAPSHOT"
 
 PREFIX ?= /usr/local
 PREFIX_ETC ?= /usr/local
+ROOT_ETC ?= /etc
 
 INCS = -Iinc -Ipro
 
-CPPFLAGS += $(INCS) -D_GNU_SOURCE -DVERSION=\"$(VERSION)\"
+CPPFLAGS += $(INCS) -D_GNU_SOURCE -DVERSION=\"$(VERSION)\" -DROOT_ETC=\"$(ROOT_ETC)\"
 
 OFLAGS = -O3
 WFLAGS = -pedantic -Wall -Wextra -Werror -Wno-unused-parameter

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -867,7 +867,7 @@ void cfg_init(void) {
 	if (!found)
 		found = resolve_paths(cfg, "/usr/local/etc", "");
 	if (!found)
-		found = resolve_paths(cfg, "/etc", "");
+		found = resolve_paths(cfg, ROOT_ETC, "");
 
 	if (found) {
 		log_info("\nFound configuration file: %s", cfg->file_path);


### PR DESCRIPTION
closes #45 

ROOT_ETC make flag may be passed in to override `/etc` configuration directory.