### PR TITLE
#60 explicitly order displays: exact match, regex match, partial match

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -65,8 +65,13 @@ ORDER:
     - '!^my_regex_here[0-9]+'
 ```
 
-Note that any item prefixed with an `!` will be interpreted as extended POSIX regex, allowing for one to easily create generic rules (e.g. "!^DP-", which will often be sufficient to put external monitors at the top of a column). Regex strings **must** be quoted otherwise its value
-will not be parsed.
+Note that any item prefixed with an `!` will be interpreted as extended POSIX regex, allowing for one to easily create generic rules (e.g. "!^DP-", which will often be sufficient to put external monitors at the top of a column). Regex strings **must** be quoted otherwise its value will not be parsed.
+
+Order will be applied as follows:
+1. Exact match
+1. Regex match
+1. Partial match
+1. Unspecified, in discovered order
 
 ### AUTO_SCALE
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -11,9 +11,9 @@ DP-3 Arrived:
 
 It is recommended to use the description rather than the name, as the name may change over time and will most likely be different on different PCs.
 
-The description does contain information about how it is connected, so strip that out. In the above example, you would use the description `Monitor Maker ABC123`.
+Using a regex is preferred, however partial string matches of at least 3 characters may be used.
 
-The name should be at least 3 characters long, to avoid any unwanted extra matches.
+The description does contain information about how it is connected, so don't match that. In the above example, you could use `!.*Monitor Maker ABC123.*` or `Monitor Maker ABC123`.
 
 ## cfg.yaml
 
@@ -67,11 +67,20 @@ ORDER:
 
 Note that any item prefixed with an `!` will be interpreted as extended POSIX regex, allowing for one to easily create generic rules (e.g. "!^DP-", which will often be sufficient to put external monitors at the top of a column). Regex strings **must** be quoted otherwise its value will not be parsed.
 
-Order will be applied as follows:
+Three passes will be made over ORDER to match displays:
 1. Exact match
 1. Regex match
 1. Partial match
-1. Unspecified, in discovered order
+Remaining displays will be used in their discovered order.
+
+Some displays may be ordered last, by using a "catchall" regex e.g.
+```yaml
+ORDER:
+    - '!.*Monitor Maker ABC123.*$'
+    - '!.*$'
+    - 'DP-5'
+```
+Note that partial matches are not possible in this configuration, and the last displays must be exactly specified.
 
 ### AUTO_SCALE
 

--- a/inc/head.h
+++ b/inc/head.h
@@ -56,9 +56,12 @@ struct Head {
 	bool warned_no_mode;
 };
 
-bool head_matches_name_desc_regex(const void *name_desc, const void *head);
+bool head_matches_name_desc_exact(const void *head, const void *name_desc);
 
-bool head_matches_name_desc_partial(const void *name_desc, const void *head);
+bool head_matches_name_desc_regex(const void *head, const void *name_desc);
+
+bool head_matches_name_desc_partial(const void *head, const void *name_desc);
+bool head_name_desc_partial_matches_head(const void *name_desc, const void *head);
 
 wl_fixed_t head_auto_scale(struct Head *head);
 

--- a/inc/list.h
+++ b/inc/list.h
@@ -14,11 +14,11 @@ struct SList *slist_append(struct SList **head, void *val);
 // remove an item, returning the val
 void *slist_remove(struct SList **head, struct SList **item);
 
-// remove items, null test is val pointer comparison
-unsigned long slist_remove_all(struct SList **head, bool (*equal)(const void *val, const void *data), const void *data);
+// remove items, null predicate is val pointer comparison
+unsigned long slist_remove_all(struct SList **head, bool (*predicate)(const void *val, const void *data), const void *data);
 
-// remove items and free vals, null test is val pointer comparison, null free_val calls free()
-unsigned long slist_remove_all_free(struct SList **head, bool (*equal)(const void *val, const void *data), const void *data, void (*free_val)(void *val));
+// remove items and free vals, null predicate is val pointer comparison, null free_val calls free()
+unsigned long slist_remove_all_free(struct SList **head, bool (*predicate)(const void *val, const void *data), const void *data, void (*free_val)(void *val));
 
 // find
 struct SList *slist_find(struct SList *head, bool (*test)(const void *val));
@@ -26,13 +26,13 @@ struct SList *slist_find(struct SList *head, bool (*test)(const void *val));
 // find a val
 void *slist_find_val(struct SList *head, bool (*test)(const void *val));
 
-// find, null test is val pointer comparison
-struct SList *slist_find_equal(struct SList *head, bool (*equal)(const void *val, const void *data), const void *data);
+// find, null predicate is val pointer comparison
+struct SList *slist_find_equal(struct SList *head, bool (*predicate)(const void *val, const void *data), const void *data);
 
-// find a val, null test is val pointer comparison
-void *slist_find_equal_val(struct SList *head, bool (*equal)(const void *val, const void *data), const void *data);
+// find a val, null predicate is val pointer comparison
+void *slist_find_equal_val(struct SList *head, bool (*predicate)(const void *val, const void *data), const void *data);
 
-// same length and every item passes test in order
+// same length and every item passes test in order, null equal compares pointers
 bool slist_equal(struct SList *a, struct SList *b, bool (*equal)(const void *a, const void *b));
 
 // length
@@ -43,6 +43,9 @@ struct SList *slist_shallow_clone(struct SList *head);
 
 // sort into a new list
 struct SList *slist_sort(struct SList *head, bool (*before)(const void *a, const void *b));
+
+// move items between lists with predicate, null predicate does nothing
+void slist_move(struct SList **to, struct SList **from, bool (*predicate)(const void *val, const void *data), const void *data);
 
 // free list
 void slist_free(struct SList **head);

--- a/src/head.c
+++ b/src/head.c
@@ -138,9 +138,14 @@ bool head_matches_name_desc_regex(const void *h, const void *n) {
 		log_debug("Could not compile regex '%s'\n", regex_pattern);
 		return false;
 	}
-	result = regexec(&regex, head->name, 0, NULL, 0);
-	if (result)
+
+	result = REG_NOMATCH;
+	if (head->name) {
+		result = regexec(&regex, head->name, 0, NULL, 0);
+	}
+	if (result && head->description) {
 		result = regexec(&regex, head->description, 0, NULL, 0);
+	}
 	if (result && result != REG_NOMATCH) {
 		regerror(result, &regex, error_msg, sizeof(error_msg));
 		log_debug("Regex match failed: %s\n", error_msg);

--- a/src/head.c
+++ b/src/head.c
@@ -23,7 +23,7 @@ bool head_is_max_preferred_refresh(struct Head *head) {
 		return false;
 
 	for (struct SList *i = cfg->max_preferred_refresh_name_desc; i; i = i->nex) {
-		if (head_matches_name_desc_partial(i->val, head)) {
+		if (head_matches_name_desc_partial(head, i->val)) {
 			return true;
 		}
 	}
@@ -31,7 +31,7 @@ bool head_is_max_preferred_refresh(struct Head *head) {
 }
 
 bool head_matches_user_mode(const void *user_mode, const void *head) {
-	return user_mode && head && head_matches_name_desc_partial(((struct UserMode*)user_mode)->name_desc, (struct Head*)head);
+	return user_mode && head && head_matches_name_desc_partial((struct Head*)head, ((struct UserMode*)user_mode)->name_desc);
 }
 
 struct Mode *preferred_mode(struct Head *head) {
@@ -120,39 +120,39 @@ struct Mode *max_mode(struct Head *head) {
 	return max;
 }
 
-bool head_matches_name_desc_regex(const void *a, const void *b) {
-	const char *name_desc = a;
-	const struct Head *head = b;
+bool head_matches_name_desc_regex(const void *h, const void *n) {
+	const struct Head *head = h;
+	const char *name_desc = n;
 
-    if (name_desc[0] != '!')
-        return false;
+	if (name_desc[0] != '!')
+		return false;
 
-    const char *regex_pattern = name_desc + 1;
+	const char *regex_pattern = name_desc + 1;
 
-    regex_t regex;
-    int result;
-    char error_msg[100];
+	regex_t regex;
+	int result;
+	char error_msg[100];
 
-    result = regcomp(&regex, regex_pattern, REG_EXTENDED);
-    if (result) {
-        log_debug("Could not compile regex '%s'\n", regex_pattern);
-        return false;
-    }
-    result = regexec(&regex, head->name, 0, NULL, 0);
-    if (result)
-        result = regexec(&regex, head->description, 0, NULL, 0);
-    if (result && result != REG_NOMATCH) {
-        regerror(result, &regex, error_msg, sizeof(error_msg));
-        log_debug("Regex match failed: %s\n", error_msg);
-    }
-    regfree(&regex);
+	result = regcomp(&regex, regex_pattern, REG_EXTENDED);
+	if (result) {
+		log_debug("Could not compile regex '%s'\n", regex_pattern);
+		return false;
+	}
+	result = regexec(&regex, head->name, 0, NULL, 0);
+	if (result)
+		result = regexec(&regex, head->description, 0, NULL, 0);
+	if (result && result != REG_NOMATCH) {
+		regerror(result, &regex, error_msg, sizeof(error_msg));
+		log_debug("Regex match failed: %s\n", error_msg);
+	}
+	regfree(&regex);
 
-    return !result;
+	return !result;
 }
 
-bool head_matches_name_desc_partial(const void *a, const void *b) {
-	const char *name_desc = a;
-	const struct Head *head = b;
+bool head_matches_name_desc_partial(const void *h, const void *n) {
+	const struct Head *head = h;
+	const char *name_desc = n;
 
 	if (!name_desc || !head || name_desc[0] == '!')
 		return false;
@@ -161,6 +161,21 @@ bool head_matches_name_desc_partial(const void *a, const void *b) {
 			(head->name && strcasestr(head->name, name_desc)) ||
 			(head->description && strcasestr(head->description, name_desc))
 		   );
+}
+
+bool head_name_desc_partial_matches_head(const void *n, const void *h) {
+	return head_matches_name_desc_partial(h, n);
+}
+
+bool head_matches_name_desc_exact(const void *h, const void *n) {
+	const struct Head *head = h;
+	const char *name_desc = n;
+
+	if (!name_desc || !head)
+		return false;
+
+	return (head->name && strcmp(head->name, name_desc) == 0) ||
+		(head->description && strcmp(head->description, name_desc) == 0);
 }
 
 wl_fixed_t head_auto_scale(struct Head *head) {

--- a/src/layout.c
+++ b/src/layout.c
@@ -19,11 +19,6 @@
 #include "server.h"
 #include "wlr-output-management-unstable-v1.h"
 
-
-
-
-
-#include <stdio.h>
 struct Head *head_changing_mode = NULL;
 struct Head *head_changing_adaptive_sync = NULL;
 

--- a/tst/GNUmakefile
+++ b/tst/GNUmakefile
@@ -1,6 +1,7 @@
 include GNUmakefile
 
 CPPFLAGS += -Itst
+COMPFLAGS += -Wno-unused-function
 
 PKGS_TST = cmocka
 CFLAGS += $(foreach p,$(PKGS_TST),$(shell pkg-config --cflags $(p)))
@@ -18,7 +19,7 @@ $(TST_O): $(TST_H) $(SRC_O) config.mk GNUmakefile tst/GNUmakefile
 tst-head: tst/tst-head.o $(filter-out src/main.o,$(SRC_O)) $(PRO_O)
 	$(CXX) -o $(@) $(^) $(LDFLAGS) $(LDLIBS) -Wl,--wrap=mode_dpi,--wrap=mode_user_mode,--wrap=log_info,--wrap=log_warn
 
-tst-layout: tst/tst-layout.o
+tst-layout: tst/tst-layout.o $(filter-out src/main.o,$(SRC_O)) $(PRO_O)
 	$(CXX) -o $(@) $(^) $(LDFLAGS) $(LDLIBS)
 
 tst-all: $(TST_E)

--- a/tst/asserts.h
+++ b/tst/asserts.h
@@ -21,14 +21,6 @@ static void _assert_wl_fixed_t_equal_double(wl_fixed_t a, double b,
 static void _assert_heads_equal(struct SList *a, struct SList *b,
 	const char * const file, const int line) {
 	if (!slist_equal(a, b, NULL)) {
-		char expected[2048];
-		char *ep = expected;
-		*ep = '\0';
-		for (struct SList *i = b; i; i = i->nex) {
-			struct Head *head = i->val;
-			ep += sprintf(ep, "\n .name = '%s', .description = '%s',", head->name, head->description);
-		}
-
 		char actual[2048];
 		char *ap = actual;
 		*ap = '\0';
@@ -37,7 +29,15 @@ static void _assert_heads_equal(struct SList *a, struct SList *b,
 			ap += sprintf(ap, "\n .name = '%s', .description = '%s',", head->name, head->description);
 		}
 
-		cmocka_print_error("assert_heads_equal\nexpected:%s\nactual:%s\n\n", expected, actual);
+		char expected[2048];
+		char *ep = expected;
+		*ep = '\0';
+		for (struct SList *i = b; i; i = i->nex) {
+			struct Head *head = i->val;
+			ep += sprintf(ep, "\n .name = '%s', .description = '%s',", head->name, head->description);
+		}
+
+		cmocka_print_error("assert_heads_equal\nactual:%s\nexpected:%s\n\n", actual, expected);
 		_fail(file, line);
 	}
 }

--- a/tst/asserts.h
+++ b/tst/asserts.h
@@ -2,8 +2,11 @@
 #define ASSERTS_H
 
 #include <cmocka.h>
+#include <stdio.h>
+#include <wayland-util.h>
 
-#include "wayland-util.h"
+#include "head.h"
+#include "list.h"
 
 static void _assert_wl_fixed_t_equal_double(wl_fixed_t a, double b,
 	const char * const file, const int line) {
@@ -14,6 +17,31 @@ static void _assert_wl_fixed_t_equal_double(wl_fixed_t a, double b,
 	}
 }
 #define assert_wl_fixed_t_equal_double(a, b) _assert_wl_fixed_t_equal_double(a, b, __FILE__, __LINE__)
+
+static void _assert_heads_equal(struct SList *a, struct SList *b,
+	const char * const file, const int line) {
+	if (!slist_equal(a, b, NULL)) {
+		char expected[2048];
+		char *ep = expected;
+		*ep = '\0';
+		for (struct SList *i = b; i; i = i->nex) {
+			struct Head *head = i->val;
+			ep += sprintf(ep, "\n .name = '%s', .description = '%s',", head->name, head->description);
+		}
+
+		char actual[2048];
+		char *ap = actual;
+		*ap = '\0';
+		for (struct SList *i = a; i; i = i->nex) {
+			struct Head *head = i->val;
+			ap += sprintf(ap, "\n .name = '%s', .description = '%s',", head->name, head->description);
+		}
+
+		cmocka_print_error("assert_heads_equal\nexpected:%s\nactual:%s\n\n", expected, actual);
+		_fail(file, line);
+	}
+}
+#define assert_heads_equal(a, b) _assert_heads_equal(a, b, __FILE__, __LINE__)
 
 #endif // ASSERTS_H
 

--- a/tst/tst-layout.c
+++ b/tst/tst-layout.c
@@ -1,6 +1,15 @@
 #include "tst.h"
+#include "asserts.h"
 
 #include <cmocka.h>
+#include <string.h>
+
+#include "head.h"
+#include "list.h"
+
+// forward declarations
+struct SList *order_heads(struct SList *order_name_desc, struct SList *heads);
+
 
 int before_all(void **state) {
 	return 0;
@@ -18,13 +27,71 @@ int after_each(void **state) {
 	return 0;
 }
 
-void blargh(void **state) {
-	assert_int_equal(1, 1);
+void order_heads__order(void **state) {
+	struct SList *order_name_desc = NULL;
+	struct SList *heads = NULL;
+	struct SList *expected = NULL;
+
+	// ORDER
+	slist_append(&order_name_desc, strdup("exact0"));
+	slist_append(&order_name_desc, strdup("exact1"));
+	slist_append(&order_name_desc, strdup("!.*regex.*"));
+	slist_append(&order_name_desc, strdup("exact1")); // should not repeat
+	slist_append(&order_name_desc, strdup("partial"));
+	slist_append(&order_name_desc, strdup("partial"));
+
+	// heads
+	struct Head head0 = { .name = "head0", .description = strdup("not specified") };
+	struct Head head1 = { .name = "head1", .description = strdup("not an exact0 exact match") };
+	struct Head head2 = { .name = "head2", .description = strdup("a partial match") };
+	struct Head head3 = { .name = "head3", .description = strdup("exact1") };
+	struct Head head4 = { .name = "head4", .description = strdup("exact0") };
+	struct Head head5 = { .name = "head5", .description = strdup("a regex match") };
+	struct Head head6 = { .name = "head6", .description = strdup("not specified") };
+	slist_append(&heads, &head0);
+	slist_append(&heads, &head1);
+	slist_append(&heads, &head2);
+	slist_append(&heads, &head3);
+	slist_append(&heads, &head4);
+	slist_append(&heads, &head5);
+	slist_append(&heads, &head6);
+
+	// expected
+	slist_append(&expected, &head4); // exact0
+	slist_append(&expected, &head1); // exact0 (partial)
+	slist_append(&expected, &head3); // exact1
+	slist_append(&expected, &head5); // !.*regex.*
+	slist_append(&expected, &head2); // partial
+	slist_append(&expected, &head0); //
+	slist_append(&expected, &head6); //
+
+	struct SList *heads_ordered = order_heads(order_name_desc, heads);
+
+	assert_heads_equal(heads_ordered, expected);
+
+	slist_free_vals(&order_name_desc, NULL);
+	slist_free(&heads);
+	slist_free(&heads_ordered);
+}
+
+void order_heads__no_order(void **state) {
+
+	struct SList *heads = NULL;
+	struct Head head = { .name = "head", };
+
+	slist_append(&heads, &head);
+
+	// null/empty order
+	struct SList *heads_ordered = order_heads(NULL, heads);
+	assert_heads_equal(heads_ordered, heads);
+
+	slist_free(&heads);
 }
 
 int main(void) {
 	const struct CMUnitTest tests[] = {
-		TEST(blargh),
+		TEST(order_heads__order),
+		TEST(order_heads__no_order),
 	};
 
 	return RUN(tests);

--- a/tst/tst-layout.c
+++ b/tst/tst-layout.c
@@ -27,7 +27,7 @@ int after_each(void **state) {
 	return 0;
 }
 
-void order_heads__order(void **state) {
+void order_heads__exact_partial_regex(void **state) {
 	struct SList *order_name_desc = NULL;
 	struct SList *heads = NULL;
 	struct SList *expected = NULL;
@@ -76,6 +76,48 @@ void order_heads__order(void **state) {
 	slist_free(&heads_ordered);
 }
 
+void order_heads__exact_regex_catchall(void **state) {
+	struct SList *order_name_desc = NULL;
+	struct SList *heads = NULL;
+	struct SList *expected = NULL;
+
+	// ORDER
+	slist_append(&order_name_desc, strdup("exact0"));
+	slist_append(&order_name_desc, strdup("!.*regex.*"));
+	slist_append(&order_name_desc, strdup("!.*$"));
+	slist_append(&order_name_desc, strdup("exact9"));
+
+	// heads
+	struct Head exact9 =          { .description = "exact9" };
+	struct Head not_specified_1 = { .description = "not specified 1", };
+	struct Head regex_match_1 =   { .description = "a regex match" };
+	struct Head exact0 =          { .description = "exact0" };
+	struct Head regex_match_2 =   { .description = "another regex match" };
+	struct Head not_specified_2 = { .description = "not specified 2" };
+	slist_append(&heads, &not_specified_1);
+	slist_append(&heads, &regex_match_1);
+	slist_append(&heads, &exact0);
+	slist_append(&heads, &regex_match_2);
+	slist_append(&heads, &not_specified_2);
+	slist_append(&heads, &exact9);
+
+	// expected
+	slist_append(&expected, &exact0);
+	slist_append(&expected, &regex_match_1);
+	slist_append(&expected, &regex_match_2);
+	slist_append(&expected, &not_specified_1);
+	slist_append(&expected, &not_specified_2);
+	slist_append(&expected, &exact9);
+
+	struct SList *heads_ordered = order_heads(order_name_desc, heads);
+
+	assert_heads_equal(heads_ordered, expected);
+
+	slist_free_vals(&order_name_desc, NULL);
+	slist_free(&heads);
+	slist_free(&heads_ordered);
+}
+
 void order_heads__no_order(void **state) {
 
 	struct SList *heads = NULL;
@@ -92,7 +134,8 @@ void order_heads__no_order(void **state) {
 
 int main(void) {
 	const struct CMUnitTest tests[] = {
-		TEST(order_heads__order),
+		TEST(order_heads__exact_partial_regex),
+		TEST(order_heads__exact_regex_catchall),
 		TEST(order_heads__no_order),
 	};
 

--- a/tst/tst-layout.c
+++ b/tst/tst-layout.c
@@ -38,32 +38,34 @@ void order_heads__order(void **state) {
 	slist_append(&order_name_desc, strdup("!.*regex.*"));
 	slist_append(&order_name_desc, strdup("exact1")); // should not repeat
 	slist_append(&order_name_desc, strdup("partial"));
-	slist_append(&order_name_desc, strdup("partial"));
 
 	// heads
-	struct Head head0 = { .name = "head0", .description = strdup("not specified") };
-	struct Head head1 = { .name = "head1", .description = strdup("not an exact0 exact match") };
-	struct Head head2 = { .name = "head2", .description = strdup("a partial match") };
-	struct Head head3 = { .name = "head3", .description = strdup("exact1") };
-	struct Head head4 = { .name = "head4", .description = strdup("exact0") };
-	struct Head head5 = { .name = "head5", .description = strdup("a regex match") };
-	struct Head head6 = { .name = "head6", .description = strdup("not specified") };
-	slist_append(&heads, &head0);
-	slist_append(&heads, &head1);
-	slist_append(&heads, &head2);
-	slist_append(&heads, &head3);
-	slist_append(&heads, &head4);
-	slist_append(&heads, &head5);
-	slist_append(&heads, &head6);
+	struct Head not_specified_1 = { .description = "not specified 1", };
+	struct Head exact0_partial =  { .description = "not an exact0 exact match" };
+	struct Head partial =         { .description = "a partial match" };
+	struct Head regex_match_1 =   { .description = "a regex match" };
+	struct Head exact1 =          { .description = "exact1" };
+	struct Head exact0 =          { .description = "exact0" };
+	struct Head regex_match_2 =   { .description = "another regex match" };
+	struct Head not_specified_2 = { .description = "not specified 2" };
+	slist_append(&heads, &not_specified_1);
+	slist_append(&heads, &exact0_partial);
+	slist_append(&heads, &partial);
+	slist_append(&heads, &regex_match_1);
+	slist_append(&heads, &exact1);
+	slist_append(&heads, &exact0);
+	slist_append(&heads, &regex_match_2);
+	slist_append(&heads, &not_specified_2);
 
 	// expected
-	slist_append(&expected, &head4); // exact0
-	slist_append(&expected, &head1); // exact0 (partial)
-	slist_append(&expected, &head3); // exact1
-	slist_append(&expected, &head5); // !.*regex.*
-	slist_append(&expected, &head2); // partial
-	slist_append(&expected, &head0); //
-	slist_append(&expected, &head6); //
+	slist_append(&expected, &exact0);
+	slist_append(&expected, &exact0_partial);
+	slist_append(&expected, &exact1);
+	slist_append(&expected, &regex_match_1);
+	slist_append(&expected, &regex_match_2);
+	slist_append(&expected, &partial);
+	slist_append(&expected, &not_specified_1);
+	slist_append(&expected, &not_specified_2);
 
 	struct SList *heads_ordered = order_heads(order_name_desc, heads);
 


### PR DESCRIPTION
ORDER is now applied:
1. Exact match
1. Regex match
1. Partial match
1. Unspecified, in discovered order

@matthewwardrop I would gratefully appreciate your review of [order_heads](https://github.com/alex-courtis/way-displays/pull/68/files#diff-e46d1522bddfcb3f1ce01830dbcf6bb21f86cb2a9dd9651cd4d41a6bc1c0faf1R99) and new test [order_heads__order](https://github.com/alex-courtis/way-displays/pull/68/files#diff-26621abfc33af6371fc72fb94f5fbd289f0903591c872b193c890f315d61a9f5R30)

TODO #46