### PR TITLE
add flake.nix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*]
+[*.{c,cpp]
 charset = utf-8
 end_of_line = lf
 indent_size = 4
@@ -15,3 +15,6 @@ max_line_length = 80
 [*.md]
 trim_trailing_whitespace = false
 
+[{*.nix,flake.lock}]
+indent_size = 2
+indent_style = space

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: "CI"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v19
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - run: nix build
+    - run: nix flake check

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pro/*.c
 /example-client
 /tst-*
 
+/.ccls-cache

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -68,7 +68,7 @@ man: way-displays.1.pandoc
 iwyu: CC = $(IWYU) -Xiwyu --check_also="inc/*h"
 iwyu: CXX = $(IWYU) -Xiwyu --check_also="inc/marshalling.h"
 iwyu: clean $(SRC_O) $(TST_O)
-IWYU = /usr/bin/include-what-you-use -Xiwyu --no_fwd_decls -Xiwyu --no_comments -Xiwyu --verbose=2
+IWYU = include-what-you-use -Xiwyu --no_fwd_decls -Xiwyu --no_comments -Xiwyu --verbose=2
 
 cppcheck: $(SRC_C) $(SRC_CXX) $(INC_H) $(EXAMPLE_C) $(TST_H) $(TST_C)
 	cppcheck $(^) --enable=warning,unusedFunction,performance,portability --suppressions-list=.cppcheck.supp $(CPPFLAGS)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1680392223,
+        "narHash": "sha256-n3g7QFr85lDODKt250rkZj2IFS3i4/8HBU2yKHO3tqw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "dcc36e45d054d7bb554c9cdab69093debd91a0b5",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1680213900,
+        "narHash": "sha256-cIDr5WZIj3EkKyCgj/6j3HBH4Jj1W296z7HTcWj1aMA=",
+        "path": "/nix/store/fb5ci6653i73gr10by36bxg2f5v69lwf-source",
+        "rev": "e3652e0735fbec227f342712f180f4f21f0594f2",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1680213900,
+        "narHash": "sha256-cIDr5WZIj3EkKyCgj/6j3HBH4Jj1W296z7HTcWj1aMA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e3652e0735fbec227f342712f180f4f21f0594f2",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "way-displays: Auto Manage Your Wayland Displays";
+
+  # nixpkgs and flake-parts are in the flake registry, so we don't have to specify their input URLs
+  # https://github.com/NixOS/flake-registry/blob/master/flake-registry.json
+  inputs = {
+  };
+
+  outputs = inputs@{ nixpkgs, flake-parts, ... }:
+    # modularize flake construction https://flake.parts/
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+      ];
+
+      # Explicitly list supported systems. Add more as needed from
+      # https://github.com/NixOS/nixpkgs/blob/master/lib/systems/flake-systems.nix
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      perSystem = { config, self', inputs', pkgs, system, ... }: {
+        # stdenv analyzes the Makefile etc and tries to "do the right thing" without much config
+        # https://nixos.org/manual/nixpkgs/unstable/#chap-stdenv
+        # Impl: https://github.com/NixOS/nixpkgs/blob/master/pkgs/stdenv/generic/setup.sh
+        # Use clangStdenv (1.2GB closure) instead of regular gcc stdenv (322MB closure).
+        # packages.default = pkgs.stdenv.mkDerivation {
+        packages.default = pkgs.clangStdenv.mkDerivation {
+          name = "way-displays";
+          version = "1.7.1+dev";
+          src = ./.;
+          # native means build system (for cross compile)
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            wayland # native for protocol code gen
+            cmocka
+          ];
+
+          # built for target system
+          buildInputs = with pkgs; [
+            wayland # target for libs
+            yaml-cpp
+            libinput
+          ];
+
+          makeFlags = [ "CC=clang CXX=clang++ DESTDIR=$(out) PREFIX= PREFIX_ETC= ROOT_ETC=$(out)/etc" ];
+          doCheck = true;
+          checkTarget = "test";
+          checkInputs = [
+            pkgs.cmocka
+          ];
+        };
+
+        # https://nixos.org/manual/nixpkgs/unstable/#sec-pkgs-mkShell
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            ccls
+            cppcheck
+            include-what-you-use
+          ];
+          inputsFrom = [ self'.packages.default ];
+        };
+      };
+    };
+}


### PR DESCRIPTION
I'm not sure if you'll be interested, but this has a number of benefits:

- Anyone with nix flakes installed can `nix run github:alex-courtis/way-displays/some-branch-or-rev`
- Reproducible dev env with `nix develop`, tests with `nix develop --check`
- Later, hooks for CI automation via [pre-commit-hooks](https://flake.parts/options/pre-commit-hooks-nix.html) and GH actions.

This is WIP but I wanted to put it up to see if you are interested or if you don't want the clutter. It would be helpful for me to contribute.