### PR TITLE
Use $PKG_CONFIG if set

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -23,10 +23,10 @@ PKGS += epoll-shim libinotify
 endif
 
 PKGS += wayland-client yaml-cpp libinput libudev
-CFLAGS += $(foreach p,$(PKGS),$(shell pkg-config --cflags $(p)))
-CXXFLAGS += $(foreach p,$(PKGS),$(shell pkg-config --cflags $(p)))
-LDLIBS += $(foreach p,$(PKGS),$(shell pkg-config --libs $(p)))
+PKG_CONFIG ?= pkg-config
+CFLAGS += $(foreach p,$(PKGS),$(shell $(PKG_CONFIG) --cflags $(p)))
+CXXFLAGS += $(foreach p,$(PKGS),$(shell $(PKG_CONFIG) --cflags $(p)))
+LDLIBS += $(foreach p,$(PKGS),$(shell $(PKG_CONFIG) --libs $(p)))
 
 CC = gcc
 CXX = g++
-


### PR DESCRIPTION
In cross-compilation environments, this will usually be set to the prefixed pkg-config executable for the platform being built for, e.g. aarch64-unknown-linux-gnu-pkg-config.