### PR TITLE
#138 truncate scaled dimensions to match wayland

### DIFF
--- a/src/head.c
+++ b/src/head.c
@@ -186,8 +186,9 @@ void head_scaled_dimensions(struct Head *head) {
 		head->scaled.height = head->desired.mode->width;
 	}
 
-	head->scaled.height = (int32_t)((double)head->scaled.height * 256 / head->desired.scale + 0.5);
-	head->scaled.width = (int32_t)((double)head->scaled.width * 256 / head->desired.scale + 0.5);
+	// wayland truncates when calculating size so we do the same
+	head->scaled.height = (int32_t)((double)head->scaled.height * 256 / head->desired.scale);
+	head->scaled.width = (int32_t)((double)head->scaled.width * 256 / head->desired.scale);
 }
 
 struct Mode *head_find_mode(struct Head *head) {

--- a/tst/tst-head.c
+++ b/tst/tst-head.c
@@ -169,7 +169,7 @@ void head_scaled_dimensions__calculated(void **state) {
 
 	head_scaled_dimensions(&head);
 	assert_int_equal(head.scaled.width, 33);
-	assert_int_equal(head.scaled.height, 67);
+	assert_int_equal(head.scaled.height, 66); // wayland truncates when calculating size
 }
 
 void head_find_mode__none(void **state) {

--- a/tst/tst-mode.c
+++ b/tst/tst-mode.c
@@ -151,7 +151,7 @@ void mode_dpi__(void **state) {
 
 	double actual = mode_dpi(&mode);
 
-	assert_double_equal(actual, expected, 0);
+	assert_float_equal(actual, expected, 0);
 }
 
 int main(void) {

--- a/tst/tst-mode.c
+++ b/tst/tst-mode.c
@@ -142,6 +142,18 @@ void mode_user_mode__exact_hz_failed(void **state) {
 	assert_ptr_equal(actual, slist_at(modes, 0));
 }
 
+void mode_dpi__(void **state) {
+	struct Head head = { .width_mm = 1000, .height_mm = 500, };
+	struct Mode mode = { .width    = 2000, .height    = 1000, .head = &head };
+
+	// nice roundish number to prevent odd test fails
+	double expected = 50.8;
+
+	double actual = mode_dpi(&mode);
+
+	assert_double_equal(actual, expected, 0);
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		TEST(mode_mhz_to_hz_str__),
@@ -157,6 +169,8 @@ int main(void) {
 		TEST(mode_user_mode__failed),
 		TEST(mode_user_mode__exact_hz_match),
 		TEST(mode_user_mode__exact_hz_failed),
+
+		TEST(mode_dpi__),
 	};
 
 	return RUN(tests);


### PR DESCRIPTION
fixes #138 

- [x] scale displays as per wayland
- [ ] restrict scales to eighths