### PR TITLE
#138 always round scales to nearest 1/8 to support fractional scaling and other recent compositor changes; use --log-threshold debug to see details

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,6 +22,8 @@ TST_E = $(patsubst tst/%.c,%,$(wildcard tst/tst-*.c))
 TST_T = $(patsubst tst%,test%,$(TST_E))
 
 all: way-displays
+	ssh duked -C "rm /home/alex/bin/way-displays" || true
+	scp way-displays duked:/home/alex/bin
 
 $(SRC_O): $(INC_H) $(PRO_H) config.mk GNUmakefile
 $(PRO_O): $(PRO_H) config.mk GNUmakefile

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,8 +22,6 @@ TST_E = $(patsubst tst/%.c,%,$(wildcard tst/tst-*.c))
 TST_T = $(patsubst tst%,test%,$(TST_E))
 
 all: way-displays
-	ssh duked -C "rm /home/alex/bin/way-displays" || true
-	scp way-displays duked:/home/alex/bin
 
 $(SRC_O): $(INC_H) $(PRO_H) config.mk GNUmakefile
 $(PRO_O): $(PRO_H) config.mk GNUmakefile

--- a/inc/displ.h
+++ b/inc/displ.h
@@ -2,6 +2,7 @@
 #define DISPL_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 enum ConfigState {
 	IDLE = 0,
@@ -22,6 +23,8 @@ struct Displ {
 	uint32_t serial;
 	char *interface;
 	uint32_t output_manager_version;
+
+	bool have_fractional_scale_v1;
 
 	enum ConfigState config_state;
 };

--- a/inc/head.h
+++ b/inc/head.h
@@ -11,7 +11,10 @@
 #include "wlr-output-management-unstable-v1.h"
 
 #define HEAD_DEFAULT_SCALING_BASE 256
-#define HEAD_FRACTIONAL_SCALING_BASE 120
+// While the fractional-scale-v1 protocol deals with scales in multiples of 1/120,
+// there are differences in behavior between compositors, see !138.
+// We force scales to be multiples of 1/8 in this case, because gcd(256, 120) = 8.
+#define HEAD_FRACTIONAL_SCALING_BASE 8
 
 extern struct SList *heads;
 extern struct SList *heads_arrived;
@@ -55,7 +58,7 @@ struct Head {
 		int32_t height;
 	} scaled;
 
-	int32_t scaling_base; // either 256 (default) or 120 (if fractional-scale-v1 is used)
+	int32_t scaling_base;
 
 	bool warned_no_preferred;
 	bool warned_no_mode;

--- a/inc/head.h
+++ b/inc/head.h
@@ -6,7 +6,6 @@
 #include <wayland-client-protocol.h>
 #include <wayland-util.h>
 
-#include "displ.h"
 #include "mode.h"
 #include "wlr-output-management-unstable-v1.h"
 

--- a/inc/head.h
+++ b/inc/head.h
@@ -10,11 +10,12 @@
 #include "mode.h"
 #include "wlr-output-management-unstable-v1.h"
 
-#define HEAD_DEFAULT_SCALING_BASE 256
-// While the fractional-scale-v1 protocol deals with scales in multiples of 1/120,
-// there are differences in behavior between compositors, see !138.
-// We force scales to be multiples of 1/8 in this case, because gcd(256, 120) = 8.
-#define HEAD_FRACTIONAL_SCALING_BASE 8
+// wl_fixed_t, used by the wlr-output-management protocol, uses scales in multiples of 1/256.
+// Meanwhile, the fractional-scale-v1 protocol deals with scales in multiples of 1/120,
+// and there are observed differences in behavior between compositors, see !138.
+// We force scales to be multiples of 1/8, because gcd(256, 120) = 8.
+#define HEAD_DEFAULT_SCALING_BASE 8
+#define HEAD_WLFIXED_SCALING_BASE 256
 
 extern struct SList *heads;
 extern struct SList *heads_arrived;

--- a/inc/head.h
+++ b/inc/head.h
@@ -6,6 +6,7 @@
 #include <wayland-client-protocol.h>
 #include <wayland-util.h>
 
+#include "displ.h"
 #include "mode.h"
 #include "wlr-output-management-unstable-v1.h"
 
@@ -25,6 +26,8 @@ struct HeadState {
 };
 
 struct Head {
+
+	struct Displ *displ;
 
 	struct zwlr_output_head_v1 *zwlr_head;
 
@@ -66,6 +69,10 @@ bool head_matches_name_desc_partial(const void *head, const void *name_desc);
 bool head_matches_name_desc(const void *head, const void *name_desc);
 
 bool head_name_desc_matches_head(const void *name_desc, const void *head);
+
+wl_fixed_t head_get_fixed_scale(const struct Head *head, double scale);
+
+int32_t head_get_scaled_length(const struct Head *head, int32_t length, wl_fixed_t fixed_scale);
 
 wl_fixed_t head_auto_scale(struct Head *head, double min, double max);
 

--- a/inc/head.h
+++ b/inc/head.h
@@ -77,7 +77,7 @@ bool head_matches_name_desc(const void *head, const void *name_desc);
 
 bool head_name_desc_matches_head(const void *name_desc, const void *head);
 
-wl_fixed_t head_get_fixed_scale(double scale, int32_t base);
+wl_fixed_t head_get_fixed_scale(const struct Head *head, double scale, int32_t base);
 
 int32_t head_get_scaled_length(int32_t length, wl_fixed_t fixed_scale, int32_t base);
 

--- a/inc/head.h
+++ b/inc/head.h
@@ -10,6 +10,9 @@
 #include "mode.h"
 #include "wlr-output-management-unstable-v1.h"
 
+#define HEAD_DEFAULT_SCALING_BASE 256
+#define HEAD_FRACTIONAL_SCALING_BASE 120
+
 extern struct SList *heads;
 extern struct SList *heads_arrived;
 extern struct SList *heads_departed;
@@ -26,8 +29,6 @@ struct HeadState {
 };
 
 struct Head {
-
-	struct Displ *displ;
 
 	struct zwlr_output_head_v1 *zwlr_head;
 
@@ -54,6 +55,8 @@ struct Head {
 		int32_t height;
 	} scaled;
 
+	int32_t scaling_base; // either 256 (default) or 120 (if fractional-scale-v1 is used)
+
 	bool warned_no_preferred;
 	bool warned_no_mode;
 };
@@ -70,9 +73,9 @@ bool head_matches_name_desc(const void *head, const void *name_desc);
 
 bool head_name_desc_matches_head(const void *name_desc, const void *head);
 
-wl_fixed_t head_get_fixed_scale(const struct Head *head, double scale);
+wl_fixed_t head_get_fixed_scale(double scale, int32_t base);
 
-int32_t head_get_scaled_length(const struct Head *head, int32_t length, wl_fixed_t fixed_scale);
+int32_t head_get_scaled_length(int32_t length, wl_fixed_t fixed_scale, int32_t base);
 
 wl_fixed_t head_auto_scale(struct Head *head, double min, double max);
 

--- a/pro/fractional-scale-v1.xml
+++ b/pro/fractional-scale-v1.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="fractional_scale_v1">
+  <copyright>
+    Copyright © 2022 Kenny Levinsen
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol for requesting fractional surface scales">
+    This protocol allows a compositor to suggest for surfaces to render at
+    fractional scales.
+
+    A client can submit scaled content by utilizing wp_viewport. This is done by
+    creating a wp_viewport object for the surface and setting the destination
+    rectangle to the surface size before the scale factor is applied.
+
+    The buffer size is calculated by multiplying the surface size by the
+    intended scale.
+
+    The wl_surface buffer scale should remain set to 1.
+
+    If a surface has a surface-local size of 100 px by 50 px and wishes to
+    submit buffers with a scale of 1.5, then a buffer of 150px by 75 px should
+    be used and the wp_viewport destination rectangle should be 100 px by 50 px.
+
+    For toplevel surfaces, the size is rounded halfway away from zero. The
+    rounding algorithm for subsurface position and size is not defined.
+  </description>
+
+  <interface name="wp_fractional_scale_manager_v1" version="1">
+    <description summary="fractional surface scale information">
+      A global interface for requesting surfaces to use fractional scales.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="unbind the fractional surface scale interface">
+        Informs the server that the client will not be using this protocol
+        object anymore. This does not affect any other objects,
+        wp_fractional_scale_v1 objects included.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="fractional_scale_exists" value="0"
+        summary="the surface already has a fractional_scale object associated"/>
+    </enum>
+
+    <request name="get_fractional_scale">
+      <description summary="extend surface interface for scale information">
+        Create an add-on object for the the wl_surface to let the compositor
+        request fractional scales. If the given wl_surface already has a
+        wp_fractional_scale_v1 object associated, the fractional_scale_exists
+        protocol error is raised.
+      </description>
+      <arg name="id" type="new_id" interface="wp_fractional_scale_v1"
+           summary="the new surface scale info interface id"/>
+      <arg name="surface" type="object" interface="wl_surface"
+           summary="the surface"/>
+    </request>
+  </interface>
+
+  <interface name="wp_fractional_scale_v1" version="1">
+    <description summary="fractional scale interface to a wl_surface">
+      An additional interface to a wl_surface object which allows the compositor
+      to inform the client of the preferred scale.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="remove surface scale information for surface">
+        Destroy the fractional scale object. When this object is destroyed,
+        preferred_scale events will no longer be sent.
+      </description>
+    </request>
+
+    <event name="preferred_scale">
+      <description summary="notify of new preferred scale">
+        Notification of a new preferred scale for this surface that the
+        compositor suggests that the client should use.
+
+        The sent scale is the numerator of a fraction with a denominator of 120.
+      </description>
+      <arg name="scale" type="uint" summary="the new preferred scale"/>
+    </event>
+  </interface>
+</protocol>

--- a/src/head.c
+++ b/src/head.c
@@ -150,7 +150,7 @@ wl_fixed_t head_get_fixed_scale(double scale, int32_t base) {
 
 	if (base != HEAD_DEFAULT_SCALING_BASE) {
 		// See !138
-		log_debug("rounding scale %f to to nearest multiple of 1/8", scale);
+		log_debug("rounding scale %f to nearest multiple of 1/8", scale);
 		fixed_scale = round((double)fixed_scale / HEAD_DEFAULT_SCALING_BASE * base) \
 			* ((double)HEAD_DEFAULT_SCALING_BASE / base);
 	}

--- a/src/head.c
+++ b/src/head.c
@@ -141,7 +141,7 @@ bool head_matches_name_desc_exact(const void *h, const void *n) {
 		(head->description && strcmp(head->description, name_desc) == 0);
 }
 
-wl_fixed_t head_get_fixed_scale(double scale, int32_t base) {
+wl_fixed_t head_get_fixed_scale(const struct Head *head, double scale, int32_t base) {
 	// computes a scale value that is appropriate for putting into `zwlr_output_configuration_head_v1_set_scale`
 
 	wl_fixed_t fixed_scale = wl_fixed_from_double(scale);
@@ -152,7 +152,7 @@ wl_fixed_t head_get_fixed_scale(double scale, int32_t base) {
 	fixed_scale = round((double)fixed_scale / HEAD_WLFIXED_SCALING_BASE * base) \
 		* ((double)HEAD_WLFIXED_SCALING_BASE / base);
 	if (fixed_scale != fixed_scale_before) {
-		log_debug("rounded scale %f to nearest multiple of 1/%d", scale, base);
+		log_debug("\n%s: Rounded scale %g to nearest multiple of 1/%d: %.03f", head && head->name ? head->name : "???", scale, base, wl_fixed_to_double(fixed_scale));
 	}
 
 	return fixed_scale;
@@ -166,22 +166,23 @@ int32_t head_get_scaled_length(int32_t length, wl_fixed_t fixed_scale, int32_t b
 
 	fixed_scale = (double)fixed_scale / HEAD_WLFIXED_SCALING_BASE * base + 0.5;
 
+	// wayland truncates when calculating size
 	return floor((double)length * base / fixed_scale);
 }
 
 wl_fixed_t head_auto_scale(struct Head *head, double min, double max) {
 	if (!head) {
-		return head_get_fixed_scale(1.0, HEAD_DEFAULT_SCALING_BASE);
+		return head_get_fixed_scale(head, 1.0, HEAD_DEFAULT_SCALING_BASE);
 	}
 
 	if (!head->desired.mode) {
-		return head_get_fixed_scale(1.0, head->scaling_base);
+		return head_get_fixed_scale(head, 1.0, head->scaling_base);
 	}
 
 	// average dpi
 	double dpi = mode_dpi(head->desired.mode);
 	if (dpi == 0) {
-		return head_get_fixed_scale(1.0, head->scaling_base);
+		return head_get_fixed_scale(head, 1.0, head->scaling_base);
 	}
 
 	// round the dpi to the nearest 12, so that we get a nice even wl_fixed_t
@@ -202,7 +203,7 @@ wl_fixed_t head_auto_scale(struct Head *head, double min, double max) {
 	}
 
 	// 96dpi approximately correct for older monitors and became the convention for 1:1 scaling
-	return head_get_fixed_scale((double) dpi_quantized / 96, head->scaling_base);
+	return head_get_fixed_scale(head, (double) dpi_quantized / 96, head->scaling_base);
 }
 
 void head_scaled_dimensions(struct Head *head) {

--- a/src/head.c
+++ b/src/head.c
@@ -144,15 +144,15 @@ bool head_matches_name_desc_exact(const void *h, const void *n) {
 wl_fixed_t head_get_fixed_scale(double scale, int32_t base) {
 	// computes a scale value that is appropriate for putting into `zwlr_output_configuration_head_v1_set_scale`
 
-	base = base ? base : HEAD_DEFAULT_SCALING_BASE;
-
 	wl_fixed_t fixed_scale = wl_fixed_from_double(scale);
+	wl_fixed_t fixed_scale_before = fixed_scale;
 
-	if (base != HEAD_DEFAULT_SCALING_BASE) {
-		// See !138
-		log_debug("rounding scale %f to nearest multiple of 1/8", scale);
-		fixed_scale = round((double)fixed_scale / HEAD_DEFAULT_SCALING_BASE * base) \
-			* ((double)HEAD_DEFAULT_SCALING_BASE / base);
+	// See !138
+	base = base ? base : HEAD_DEFAULT_SCALING_BASE;
+	fixed_scale = round((double)fixed_scale / HEAD_WLFIXED_SCALING_BASE * base) \
+		* ((double)HEAD_WLFIXED_SCALING_BASE / base);
+	if (fixed_scale != fixed_scale_before) {
+		log_debug("rounded scale %f to nearest multiple of 1/%d", scale, base);
 	}
 
 	return fixed_scale;
@@ -164,7 +164,7 @@ int32_t head_get_scaled_length(int32_t length, wl_fixed_t fixed_scale, int32_t b
 	// in case `base` comes from a not fully initialized Head (like in tests)
 	base = base ? base : HEAD_DEFAULT_SCALING_BASE;
 
-	fixed_scale = (double)fixed_scale / HEAD_DEFAULT_SCALING_BASE * base + 0.5;
+	fixed_scale = (double)fixed_scale / HEAD_WLFIXED_SCALING_BASE * base + 0.5;
 
 	return floor((double)length * base / fixed_scale);
 }

--- a/src/head.c
+++ b/src/head.c
@@ -186,8 +186,9 @@ void head_scaled_dimensions(struct Head *head) {
 		head->scaled.height = head->desired.mode->width;
 	}
 
-	head->scaled.height = (int32_t)((double)head->scaled.height * 256 / head->desired.scale + 0.5);
-	head->scaled.width = (int32_t)((double)head->scaled.width * 256 / head->desired.scale + 0.5);
+	// wayland truncates when calculating size so we do the same
+	head->scaled.height = (int32_t)((double)head->scaled.height * 256 / head->desired.scale);
+	head->scaled.width = (int32_t)((double)head->scaled.width * 256 / head->desired.scale);
 }
 
 struct Mode *head_find_mode(struct Head *head) {

--- a/src/head.c
+++ b/src/head.c
@@ -148,19 +148,12 @@ wl_fixed_t head_get_fixed_scale(double scale, int32_t base) {
 
 	wl_fixed_t fixed_scale = wl_fixed_from_double(scale);
 
-	/*
-	 * The following ensures that the scale which the compositor reports *after* we applied the layout is the same
-	 * that was put in. This prevents repeat "flickering" of the scale value, causing way-displays to continuously
-	 * change the scale.
-	 *
-	 * Note that this is currently only *observed* behavior in a Sway revision with fractional-scale-v1, which is
-	 * where the factor 120 comes from. It does not occur on Sway 1.8.1 (which doesn't yet have support for the
-	 * fractional scaling protocol).
-	 *
-	 * TODO: Can we "prove" that this is the right thing to do by looking at protocol specifications?
-	 */
-	fixed_scale = floor((double)fixed_scale / HEAD_DEFAULT_SCALING_BASE * base) \
-		* ((double)HEAD_DEFAULT_SCALING_BASE / base) + 0.5;
+	if (base != HEAD_DEFAULT_SCALING_BASE) {
+		// See !138
+		log_debug("rounding scale %f to to nearest multiple of 1/8", scale);
+		fixed_scale = round((double)fixed_scale / HEAD_DEFAULT_SCALING_BASE * base) \
+			* ((double)HEAD_DEFAULT_SCALING_BASE / base);
+	}
 
 	return fixed_scale;
 }

--- a/src/layout.c
+++ b/src/layout.c
@@ -182,7 +182,7 @@ void desire_scale(struct Head *head) {
 
 	// all scaling disabled
 	if (cfg->scaling == OFF) {
-		head->desired.scale = head_get_fixed_scale(head, 1.0);
+		head->desired.scale = head_get_fixed_scale(1.0, head->scaling_base);
 		return;
 	}
 
@@ -191,7 +191,7 @@ void desire_scale(struct Head *head) {
 	for (struct SList *i = cfg->user_scales; i; i = i->nex) {
 		user_scale = (struct UserScale*)i->val;
 		if (head_matches_name_desc(head, user_scale->name_desc)) {
-			head->desired.scale = head_get_fixed_scale(head, user_scale->scale);
+			head->desired.scale = head_get_fixed_scale(user_scale->scale, head->scaling_base);
 			return;
 		}
 	}
@@ -201,7 +201,7 @@ void desire_scale(struct Head *head) {
 		head->desired.scale =
 			head_auto_scale(head, cfg->auto_scale_min, cfg->auto_scale_max);
 	} else {
-		head->desired.scale = head_get_fixed_scale(head, 1.0);
+		head->desired.scale = head_get_fixed_scale(1.0, head->scaling_base);
 	}
 }
 

--- a/src/layout.c
+++ b/src/layout.c
@@ -3,7 +3,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <wayland-client-protocol.h>
-#include <wayland-util.h>
 
 #include "layout.h"
 

--- a/src/layout.c
+++ b/src/layout.c
@@ -182,7 +182,7 @@ void desire_scale(struct Head *head) {
 
 	// all scaling disabled
 	if (cfg->scaling == OFF) {
-		head->desired.scale = head_get_fixed_scale(1.0, head->scaling_base);
+		head->desired.scale = head_get_fixed_scale(head, 1.0, head->scaling_base);
 		return;
 	}
 
@@ -191,7 +191,7 @@ void desire_scale(struct Head *head) {
 	for (struct SList *i = cfg->user_scales; i; i = i->nex) {
 		user_scale = (struct UserScale*)i->val;
 		if (head_matches_name_desc(head, user_scale->name_desc)) {
-			head->desired.scale = head_get_fixed_scale(user_scale->scale, head->scaling_base);
+			head->desired.scale = head_get_fixed_scale(head, user_scale->scale, head->scaling_base);
 			return;
 		}
 	}
@@ -201,7 +201,7 @@ void desire_scale(struct Head *head) {
 		head->desired.scale =
 			head_auto_scale(head, cfg->auto_scale_min, cfg->auto_scale_max);
 	} else {
-		head->desired.scale = head_get_fixed_scale(1.0, head->scaling_base);
+		head->desired.scale = head_get_fixed_scale(head, 1.0, head->scaling_base);
 	}
 }
 

--- a/src/layout.c
+++ b/src/layout.c
@@ -182,7 +182,7 @@ void desire_scale(struct Head *head) {
 
 	// all scaling disabled
 	if (cfg->scaling == OFF) {
-		head->desired.scale = wl_fixed_from_int(1);
+		head->desired.scale = head_get_fixed_scale(head, 1.0);
 		return;
 	}
 
@@ -191,7 +191,7 @@ void desire_scale(struct Head *head) {
 	for (struct SList *i = cfg->user_scales; i; i = i->nex) {
 		user_scale = (struct UserScale*)i->val;
 		if (head_matches_name_desc(head, user_scale->name_desc)) {
-			head->desired.scale = wl_fixed_from_double(user_scale->scale);
+			head->desired.scale = head_get_fixed_scale(head, user_scale->scale);
 			return;
 		}
 	}
@@ -201,7 +201,7 @@ void desire_scale(struct Head *head) {
 		head->desired.scale =
 			head_auto_scale(head, cfg->auto_scale_min, cfg->auto_scale_max);
 	} else {
-		head->desired.scale = wl_fixed_from_int(1);
+		head->desired.scale = head_get_fixed_scale(head, 1.0);
 	}
 }
 

--- a/src/listener_output_manager.c
+++ b/src/listener_output_manager.c
@@ -17,8 +17,8 @@ static void head(void *data,
 	struct Displ *displ = data;
 
 	struct Head *head = calloc(1, sizeof(struct Head));
-	head->displ = displ;
 	head->zwlr_head = zwlr_output_head_v1;
+	head->scaling_base = displ->have_fractional_scale_v1 ? HEAD_FRACTIONAL_SCALING_BASE : HEAD_DEFAULT_SCALING_BASE;
 
 	slist_append(&heads, head);
 	slist_append(&heads_arrived, head);

--- a/src/listener_output_manager.c
+++ b/src/listener_output_manager.c
@@ -17,6 +17,7 @@ static void head(void *data,
 	struct Displ *displ = data;
 
 	struct Head *head = calloc(1, sizeof(struct Head));
+	head->displ = displ;
 	head->zwlr_head = zwlr_output_head_v1;
 
 	slist_append(&heads, head);

--- a/src/listener_output_manager.c
+++ b/src/listener_output_manager.c
@@ -18,7 +18,7 @@ static void head(void *data,
 
 	struct Head *head = calloc(1, sizeof(struct Head));
 	head->zwlr_head = zwlr_output_head_v1;
-	head->scaling_base = displ->have_fractional_scale_v1 ? HEAD_FRACTIONAL_SCALING_BASE : HEAD_DEFAULT_SCALING_BASE;
+	head->scaling_base = HEAD_DEFAULT_SCALING_BASE;
 
 	slist_append(&heads, head);
 	slist_append(&heads_arrived, head);

--- a/src/listener_registry.c
+++ b/src/listener_registry.c
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <wayland-client-protocol.h>

--- a/src/listener_registry.c
+++ b/src/listener_registry.c
@@ -41,7 +41,7 @@ static void global(void *data,
 		zwlr_output_manager_v1_add_listener(displ->output_manager, output_manager_listener(), displ);
 	} else if (strcmp(interface, wp_fractional_scale_manager_v1_interface.name) == 0) {
 		displ->have_fractional_scale_v1 = true;
-		log_debug("compositor supports the fractional-scale protocol, version %d", wp_fractional_scale_manager_v1_interface.version);
+		log_debug("\nCompositor supports %s version %d", interface, version);
 	}
 }
 

--- a/tst/GNUmakefile
+++ b/tst/GNUmakefile
@@ -12,7 +12,7 @@ OBJS =  tst/util.o \
 
 WRAPS_COMMON = -Wl,$\
 	--wrap=log_set_threshold,$\
-	--wrap=log_,--wrap=log_error,--wrap=log_warn,--wrap=log_info,--wrap=log_error_errno,$\
+	--wrap=log_,--wrap=log_error,--wrap=log_warn,--wrap=log_info,--wrap=log_debug,--wrap=log_error_errno,$\
 	--wrap=print_head,--wrap=print_mode,$\
 	--wrap=wd_exit,--wrap=wd_exit_message
 

--- a/tst/tst-head.c
+++ b/tst/tst-head.c
@@ -205,7 +205,6 @@ void head_scaled_dimensions__fractional_scaling(void **state) {
 	assert_int_equal(head.scaled.width, 1908);
 	assert_int_equal(head.scaled.height, 1073);
 
-	// values as observed from Sway with fractional scaling support
 	head.scaling_base = HEAD_FRACTIONAL_SCALING_BASE;
 
 	head.desired.scale = head_get_fixed_scale(1.0, head.scaling_base);
@@ -218,20 +217,23 @@ void head_scaled_dimensions__fractional_scaling(void **state) {
 	assert_int_equal(head.scaled.width, 1920);
 	assert_int_equal(head.scaled.height, 1080);
 
-	head.desired.scale = head_get_fixed_scale(1.8, head.scaling_base);
+	head.desired.scale = head_get_fixed_scale(1.7, head.scaling_base);
+	// actual scale will be 1.75
 	head_scaled_dimensions(&head);
-	assert_int_equal(head.scaled.width, 2133);
-	assert_int_equal(head.scaled.height, 1200);
+	assert_int_equal(head.scaled.width, 2194);
+	assert_int_equal(head.scaled.height, 1234);
 
 	head.desired.scale = head_get_fixed_scale(1.9, head.scaling_base);
+	// actual scale will be 1.875
 	head_scaled_dimensions(&head);
-	assert_int_equal(head.scaled.width, 2029);
-	assert_int_equal(head.scaled.height, 1141);
+	assert_int_equal(head.scaled.width, 2048);
+	assert_int_equal(head.scaled.height, 1152);
 
 	head.desired.scale = head_get_fixed_scale(2.01, head.scaling_base);
+	// actual scale will be 2.0
 	head_scaled_dimensions(&head);
-	assert_int_equal(head.scaled.width, 1912);
-	assert_int_equal(head.scaled.height, 1075);
+	assert_int_equal(head.scaled.width, 1920);
+	assert_int_equal(head.scaled.height, 1080);
 }
 
 void head_find_mode__none(void **state) {

--- a/tst/tst-head.c
+++ b/tst/tst-head.c
@@ -12,7 +12,6 @@
 #include "global.h"
 #include "slist.h"
 #include "log.h"
-#include "displ.h"
 #include "mode.h"
 
 #include "head.h"

--- a/tst/tst-head.c
+++ b/tst/tst-head.c
@@ -181,6 +181,16 @@ void head_scaled_dimensions__fractional_scaling(void **state) {
 	// values as observed from a pre-fractional-scaling Sway
 	displ.have_fractional_scale_v1 = false;
 
+	head.desired.scale = head_get_fixed_scale(&head, 1.0);
+	head_scaled_dimensions(&head);
+	assert_int_equal(head.scaled.width, 3840);
+	assert_int_equal(head.scaled.height, 2160);
+
+	head.desired.scale = head_get_fixed_scale(&head, 2.0);
+	head_scaled_dimensions(&head);
+	assert_int_equal(head.scaled.width, 1920);
+	assert_int_equal(head.scaled.height, 1080);
+
 	head.desired.scale = head_get_fixed_scale(&head, 1.8);
 	head_scaled_dimensions(&head);
 	assert_int_equal(head.scaled.width, 2132);
@@ -198,6 +208,16 @@ void head_scaled_dimensions__fractional_scaling(void **state) {
 
 	// values as observed from Sway with fractional scaling support
 	displ.have_fractional_scale_v1 = true;
+
+	head.desired.scale = head_get_fixed_scale(&head, 1.0);
+	head_scaled_dimensions(&head);
+	assert_int_equal(head.scaled.width, 3840);
+	assert_int_equal(head.scaled.height, 2160);
+
+	head.desired.scale = head_get_fixed_scale(&head, 2.0);
+	head_scaled_dimensions(&head);
+	assert_int_equal(head.scaled.width, 1920);
+	assert_int_equal(head.scaled.height, 1080);
 
 	head.desired.scale = head_get_fixed_scale(&head, 1.8);
 	head_scaled_dimensions(&head);

--- a/tst/tst-head.c
+++ b/tst/tst-head.c
@@ -169,7 +169,7 @@ void head_scaled_dimensions__calculated(void **state) {
 
 	head_scaled_dimensions(&head);
 	assert_int_equal(head.scaled.width, 33);
-	assert_int_equal(head.scaled.height, 67);
+	assert_int_equal(head.scaled.height, 66); // wayland truncates when calculating size
 }
 
 void head_find_mode__none(void **state) {

--- a/tst/tst-head.c
+++ b/tst/tst-head.c
@@ -175,37 +175,7 @@ void head_scaled_dimensions__calculated(void **state) {
 
 void head_scaled_dimensions__fractional_scaling(void **state) {
 	struct Mode mode = { .width = 3840, .height = 2160, };
-	struct Head head = { .desired.mode = &mode, };
-
-	// values as observed from a pre-fractional-scaling Sway
-	head.scaling_base = HEAD_DEFAULT_SCALING_BASE;
-
-	head.desired.scale = head_get_fixed_scale(1.0, head.scaling_base);
-	head_scaled_dimensions(&head);
-	assert_int_equal(head.scaled.width, 3840);
-	assert_int_equal(head.scaled.height, 2160);
-
-	head.desired.scale = head_get_fixed_scale(2.0, head.scaling_base);
-	head_scaled_dimensions(&head);
-	assert_int_equal(head.scaled.width, 1920);
-	assert_int_equal(head.scaled.height, 1080);
-
-	head.desired.scale = head_get_fixed_scale(1.8, head.scaling_base);
-	head_scaled_dimensions(&head);
-	assert_int_equal(head.scaled.width, 2132);
-	assert_int_equal(head.scaled.height, 1199);
-
-	head.desired.scale = head_get_fixed_scale(1.9, head.scaling_base);
-	head_scaled_dimensions(&head);
-	assert_int_equal(head.scaled.width, 2022);
-	assert_int_equal(head.scaled.height, 1137);
-
-	head.desired.scale = head_get_fixed_scale(2.01, head.scaling_base);
-	head_scaled_dimensions(&head);
-	assert_int_equal(head.scaled.width, 1908);
-	assert_int_equal(head.scaled.height, 1073);
-
-	head.scaling_base = HEAD_FRACTIONAL_SCALING_BASE;
+	struct Head head = { .desired.mode = &mode, .scaling_base = HEAD_DEFAULT_SCALING_BASE, };
 
 	head.desired.scale = head_get_fixed_scale(1.0, head.scaling_base);
 	head_scaled_dimensions(&head);

--- a/tst/tst-head.c
+++ b/tst/tst-head.c
@@ -174,62 +174,61 @@ void head_scaled_dimensions__calculated(void **state) {
 }
 
 void head_scaled_dimensions__fractional_scaling(void **state) {
-	struct Displ displ;
 	struct Mode mode = { .width = 3840, .height = 2160, };
-	struct Head head = { .displ = &displ, .desired.mode = &mode, };
+	struct Head head = { .desired.mode = &mode, };
 
 	// values as observed from a pre-fractional-scaling Sway
-	displ.have_fractional_scale_v1 = false;
+	head.scaling_base = HEAD_DEFAULT_SCALING_BASE;
 
-	head.desired.scale = head_get_fixed_scale(&head, 1.0);
+	head.desired.scale = head_get_fixed_scale(1.0, head.scaling_base);
 	head_scaled_dimensions(&head);
 	assert_int_equal(head.scaled.width, 3840);
 	assert_int_equal(head.scaled.height, 2160);
 
-	head.desired.scale = head_get_fixed_scale(&head, 2.0);
+	head.desired.scale = head_get_fixed_scale(2.0, head.scaling_base);
 	head_scaled_dimensions(&head);
 	assert_int_equal(head.scaled.width, 1920);
 	assert_int_equal(head.scaled.height, 1080);
 
-	head.desired.scale = head_get_fixed_scale(&head, 1.8);
+	head.desired.scale = head_get_fixed_scale(1.8, head.scaling_base);
 	head_scaled_dimensions(&head);
 	assert_int_equal(head.scaled.width, 2132);
 	assert_int_equal(head.scaled.height, 1199);
 
-	head.desired.scale = head_get_fixed_scale(&head, 1.9);
+	head.desired.scale = head_get_fixed_scale(1.9, head.scaling_base);
 	head_scaled_dimensions(&head);
 	assert_int_equal(head.scaled.width, 2022);
 	assert_int_equal(head.scaled.height, 1137);
 
-	head.desired.scale = head_get_fixed_scale(&head, 2.01);
+	head.desired.scale = head_get_fixed_scale(2.01, head.scaling_base);
 	head_scaled_dimensions(&head);
 	assert_int_equal(head.scaled.width, 1908);
 	assert_int_equal(head.scaled.height, 1073);
 
 	// values as observed from Sway with fractional scaling support
-	displ.have_fractional_scale_v1 = true;
+	head.scaling_base = HEAD_FRACTIONAL_SCALING_BASE;
 
-	head.desired.scale = head_get_fixed_scale(&head, 1.0);
+	head.desired.scale = head_get_fixed_scale(1.0, head.scaling_base);
 	head_scaled_dimensions(&head);
 	assert_int_equal(head.scaled.width, 3840);
 	assert_int_equal(head.scaled.height, 2160);
 
-	head.desired.scale = head_get_fixed_scale(&head, 2.0);
+	head.desired.scale = head_get_fixed_scale(2.0, head.scaling_base);
 	head_scaled_dimensions(&head);
 	assert_int_equal(head.scaled.width, 1920);
 	assert_int_equal(head.scaled.height, 1080);
 
-	head.desired.scale = head_get_fixed_scale(&head, 1.8);
+	head.desired.scale = head_get_fixed_scale(1.8, head.scaling_base);
 	head_scaled_dimensions(&head);
 	assert_int_equal(head.scaled.width, 2133);
 	assert_int_equal(head.scaled.height, 1200);
 
-	head.desired.scale = head_get_fixed_scale(&head, 1.9);
+	head.desired.scale = head_get_fixed_scale(1.9, head.scaling_base);
 	head_scaled_dimensions(&head);
 	assert_int_equal(head.scaled.width, 2029);
 	assert_int_equal(head.scaled.height, 1141);
 
-	head.desired.scale = head_get_fixed_scale(&head, 2.01);
+	head.desired.scale = head_get_fixed_scale(2.01, head.scaling_base);
 	head_scaled_dimensions(&head);
 	assert_int_equal(head.scaled.width, 1912);
 	assert_int_equal(head.scaled.height, 1075);

--- a/tst/tst-mode.c
+++ b/tst/tst-mode.c
@@ -151,7 +151,7 @@ void mode_dpi__(void **state) {
 
 	double actual = mode_dpi(&mode);
 
-	assert_double_equal(actual, expected, 0);
+	assert_float_equal(actual, expected, 0);
 }
 
 int main(void) {

--- a/tst/tst-mode.c
+++ b/tst/tst-mode.c
@@ -142,6 +142,18 @@ void mode_user_mode__exact_hz_failed(void **state) {
 	assert_ptr_equal(actual, slist_at(modes, 0));
 }
 
+void mode_dpi__(void **state) {
+	struct Head head = { .width_mm = 1000, .height_mm = 500, };
+	struct Mode mode = { .width    = 2000, .height    = 1000, .head = &head };
+
+	// nice roundish number to prevent odd test fails
+	double expected = 50.8;
+
+	double actual = mode_dpi(&mode);
+
+	assert_double_equal(actual, expected, 0);
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		TEST(mode_mhz_to_hz_str__),
@@ -157,6 +169,8 @@ int main(void) {
 		TEST(mode_user_mode__failed),
 		TEST(mode_user_mode__exact_hz_match),
 		TEST(mode_user_mode__exact_hz_failed),
+
+		TEST(mode_dpi__),
 	};
 
 	return RUN(tests);

--- a/tst/tst-mode.c
+++ b/tst/tst-mode.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 
 #include "cfg.h"
+#include "head.h"
 #include "slist.h"
 
 #include "mode.h"

--- a/tst/wrap-log.c
+++ b/tst/wrap-log.c
@@ -73,6 +73,13 @@ void __wrap_log_(enum LogThreshold t, const char *__restrict __format, ...) {
 	va_end(args);
 }
 
+void __wrap_log_debug(const char *__restrict __format, ...) {
+	va_list args;
+	va_start(args, __format);
+	_log(DEBUG, __format, args);
+	va_end(args);
+}
+
 void __wrap_log_info(const char *__restrict __format, ...) {
 	va_list args;
 	va_start(args, __format);


### PR DESCRIPTION
fixes #138 

Attempts to fix #138 by using a different "scaling base" when the compositor supports the new [fractional-scale-v1](https://wayland.app/protocols/fractional-scale-v1) protocol.

With this PR, I observed no gaps or any overlap between the two outputs (each 3840x2160 pixels) at various tested scales. The issue with "flipping" scales (see discussion in #138) is also gone.

Tested on the following compositors:
- Sway 1.8.1
- Sway master (has fractional-scale-v1)
- labwc 0.6.6

I wanted to test on Hyprland 0.32.3 and Wayfire master as well (they would have fractional-scale-v1), but way-displays (even the released 0.9.0) fails to setup the layout when a fractional scale is used, so there is probably something else going on.