### PR TITLE
docs: explicitly state that Hyprland is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ See wiki for [Configuration](https://github.com/alex-courtis/way-displays/wiki/C
 
 A wlroots based compositor that supports the WLR Output Management protocol.
 
-way-displays is blessed for the [sway](https://swaywm.org/) and [river](https://github.com/riverwm/river). It may work on others.
+way-displays is blessed for the [sway](https://swaywm.org/) and [river](https://github.com/riverwm/river). It may work on others; please tell me of your experiences!
 
-[Hpyrland](https://hyprland.org/) provides all way-displays functionality and you may experience issues.
+[Hpyrland](https://hyprland.org/) already provides all the features of `way-displays`. It may function, however it is explicitly not supported and you will likely experience problems. Please do not raise issues.
 
 way-displays must be run as a daemon, a background server process. It will respond to your configuration changes as well as state changes such as plugging in a monitor or closing the lid.
 

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,10 @@ main(int argc, char **argv) {
 		return EXIT_FAILURE;
 	}
 
+	if (getenv("HYPRLAND_INSTANCE_SIGNATURE")) {
+		log_warn("Hpyrland already provides all the features of `way-displays`. It may function, however it is explicitly not supported and you will likely experience problems. Please do not raise issues.");
+	}
+
 	// consumer frees
 	struct IpcRequest *ipc_request = NULL;
 	char *cfg_path = NULL;


### PR DESCRIPTION
fixes #209 

Hyprland explicitly not supported.

Wiki updated: https://github.com/alex-courtis/way-displays/wiki/FAQ/_compare/ed310779a9df347f84b24c5e2729c47fec227529...1ce2d4a50546739e3780ebe09e862cd3f8f0b7d7