### PR TITLE
docs: add a note about "development" dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Please raise an [issue](https://github.com/alex-courtis/way-displays/issues), fo
 
 Most will be available if you are running a wlroots based compositor like sway.
 
-yaml-cpp will need to be installed via your distribution's package manager.
+yaml-cpp will need to be installed via your distribution's package manager. Note that if your distribution decouples libraries from their headers you will need to install the "development" versions of these packages (with the exception of make/gcc/glang).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The server responds to [IPC](https://github.com/alex-courtis/way-displays/wiki/I
 
 [![CI](https://github.com/alex-courtis/way-displays/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/alex-courtis/way-displays/actions/workflows/ci.yml?query=branch%3Amaster)
 
-See [CONTRIBUTING](doc/CONTRIBUTING.md)
+See [CONTRIBUTING](CONTRIBUTING.md) for a list of the dependencies you'll need.
 
 #### Install / Uninstall
 


### PR DESCRIPTION
some distros (e.g. fedora, ubuntu, debian) separate libraries and the header files necessary to develop against them, putting the later in separate packages (often appended by "-devel" or "-dev").

many of the developers using these distros may already be aware of this. and/but ime the way that people _become_ aware is often via (repeated) exposure to reminders in docs like these. :) <3

ignorance or inattention to this fact (something that I do often, lol) is often what results in bug reports that look like #217 

also fixes a broken link to the contributing doc


I did also notice that this issue will extend to the development dependencies `cmocka` and `cppcheck`, which are required for testing changes but not explicitly mentioned in the contributing guide. I wasn't sure where/whether to note that, though, as I ultimately hesitated to change the docs too much.