### PR TITLE
fix(#243): safer logging

### DIFF
--- a/bld/cppcheck.supp
+++ b/bld/cppcheck.supp
@@ -3,6 +3,9 @@
 
 staticFunction:yaml/*-types.c
 
+staticFunction:log.c
+unusedFunction:log.c
+
 unusedFunction:src/convert.c
 
 unusedFunction:lib/col/*c

--- a/inc/log.h
+++ b/inc/log.h
@@ -1,6 +1,7 @@
 #ifndef LOG_H
 #define LOG_H
 
+#include <stdarg.h>
 #include <stdbool.h>
 
 #include "slist.h"
@@ -61,6 +62,9 @@ void log_cap_lines_free(struct SList **log_cap_lines);
 
 void log_cap_lines_playback(struct SList *log_cap_lines);
 
+
+// vsprintf to a malloc'd buffer, does not mutate __args
+char *vsprintf_alloc(const char *__restrict __format, va_list __args);
 
 // sprintf to a malloc'd buffer
 char *sprintf_alloc(const char *__restrict __format, ...) __attribute__ ((__format__ (__printf__, 1, 2)));

--- a/inc/log.h
+++ b/inc/log.h
@@ -3,6 +3,7 @@
 
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "slist.h"
 

--- a/inc/log.h
+++ b/inc/log.h
@@ -66,6 +66,9 @@ void log_cap_lines_playback(struct SList *log_cap_lines);
 // vsprintf to a malloc'd buffer, does not mutate __args
 char *vsprintf_alloc(const char *__restrict __format, va_list __args);
 
+// vsnprintf to a malloc'd buffer, does not mutate __args
+char *vsnprintf_alloc(size_t __maxlen, const char *__restrict __format, va_list __args);
+
 // sprintf to a malloc'd buffer
 char *sprintf_alloc(const char *__restrict __format, ...) __attribute__ ((__format__ (__printf__, 1, 2)));
 

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -1019,7 +1019,8 @@ end:
 	free(yaml);
 
 	if (written) {
-		log_info("\nWrote configuration file: %s", cfg->file_path);
+		log_info("");
+		log_info("Wrote configuration file: %s", cfg->file_path);
 	}
 }
 

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -231,7 +231,8 @@ static bool invalid_user_scale(const void *a, const void *b) {
 	struct UserScale *user_scale = (struct UserScale*)a;
 
 	if (user_scale->scale <= 0) {
-		log_warn("\nIgnoring non-positive SCALE %s %.3f", user_scale->name_desc, user_scale->scale);
+		log_warn("");
+		log_warn("Ignoring non-positive SCALE %s %.3f", user_scale->name_desc, user_scale->scale);
 		return true;
 	}
 
@@ -245,25 +246,30 @@ static bool invalid_user_mode(const void *a, const void *b) {
 	struct UserMode *user_mode = (struct UserMode*)a;
 
 	if (user_mode->width != -1 && user_mode->width <= 0) {
-		log_warn("\nIgnoring non-positive MODE %s WIDTH %d", user_mode->name_desc, user_mode->width);
+		log_warn("");
+		log_warn("Ignoring non-positive MODE %s WIDTH %d", user_mode->name_desc, user_mode->width);
 		return true;
 	}
 	if (user_mode->height != -1 && user_mode->height <= 0) {
-		log_warn("\nIgnoring non-positive MODE %s HEIGHT %d", user_mode->name_desc, user_mode->height);
+		log_warn("");
+		log_warn("Ignoring non-positive MODE %s HEIGHT %d", user_mode->name_desc, user_mode->height);
 		return true;
 	}
 	if (user_mode->refresh_mhz != -1 && user_mode->refresh_mhz <= 0) {
-		log_warn("\nIgnoring non-positive MODE %s HZ %s", user_mode->name_desc, mhz_to_hz_str(user_mode->refresh_mhz));
+		log_warn("");
+		log_warn("Ignoring non-positive MODE %s HZ %s", user_mode->name_desc, mhz_to_hz_str(user_mode->refresh_mhz));
 		return true;
 	}
 
 	if (!user_mode->max) {
 		if (user_mode->width == -1) {
-			log_warn("\nIgnoring invalid MODE %s missing WIDTH", user_mode->name_desc);
+			log_warn("");
+			log_warn("Ignoring invalid MODE %s missing WIDTH", user_mode->name_desc);
 			return true;
 		}
 		if (user_mode->height == -1) {
-			log_warn("\nIgnoring invalid MODE %s missing HEIGHT", user_mode->name_desc);
+			log_warn("");
+			log_warn("Ignoring invalid MODE %s missing HEIGHT", user_mode->name_desc);
 			return true;
 		}
 	}
@@ -276,11 +282,13 @@ static void warn_ambiguous_name_desc(const char *name_desc, const char *element)
 		return;
 
 	if (strlen(name_desc) < 4) {
-		log_warn("\n%s '%s' is less than 4 characters, which may result in some unwanted matches.", element, name_desc);
+		log_warn("");
+		log_warn("%s '%s' is less than 4 characters, which may result in some unwanted matches.", element, name_desc);
 	}
 
 	if (strcmp(name_desc, "DP-1") == 0) {
-		log_warn("\n%s '%s' will match eDP-1 and DP-1. Consider using regex '!^DP-1$' to exactly match.", element, name_desc);
+		log_warn("");
+		log_warn("%s '%s' will match eDP-1 and DP-1. Consider using regex '!^DP-1$' to exactly match.", element, name_desc);
 	}
 }
 
@@ -597,7 +605,8 @@ static void remove_duplicate_user_scales(struct Cfg *cfg) {
 		const struct UserScale *user_scale = i->val;
 		const struct UserScale *dup = stable_put(by_name_desc, user_scale->name_desc, user_scale);
 		if (dup) {
-			log_warn("\nRemoving duplicate SCALE %s", dup->name_desc);
+			log_warn("");
+			log_warn("Removing duplicate SCALE %s", dup->name_desc);
 			cfg_user_scale_free(dup);
 		}
 	}
@@ -614,7 +623,8 @@ static void remove_duplicate_user_modes(struct Cfg *cfg) {
 		const struct UserMode *mode = i->val;
 		const struct UserMode *dup = stable_put(by_name_desc, mode->name_desc, mode);
 		if (dup) {
-			log_warn("\nRemoving duplicate MODE %s", dup->name_desc);
+			log_warn("");
+			log_warn("Removing duplicate MODE %s", dup->name_desc);
 			cfg_user_mode_free(dup);
 		}
 	}
@@ -631,7 +641,8 @@ static void remove_duplicate_user_transforms(struct Cfg *cfg) {
 		const struct UserTransform *transform = i->val;
 		const struct UserTransform *dup = stable_put(by_name_desc, transform->name_desc, transform);
 		if (dup) {
-			log_warn("\nRemoving duplicate TRANSFORM %s", dup->name_desc);
+			log_warn("");
+			log_warn("Removing duplicate TRANSFORM %s", dup->name_desc);
 			cfg_user_transform_free(dup);
 		}
 	}
@@ -648,7 +659,8 @@ static void remove_duplicate_disabled(struct Cfg *cfg) {
 		const struct Disabled *disabled = i->val;
 		const struct Disabled *dup = stable_put(by_name_desc, disabled->name_desc, disabled);
 		if (dup) {
-			log_warn("\nRemoving duplicate DISABLED %s", dup->name_desc);
+			log_warn("");
+			log_warn("Removing duplicate DISABLED %s", dup->name_desc);
 			cfg_disabled_free(dup);
 		}
 	}
@@ -667,14 +679,16 @@ void validate_fix(struct Cfg *cfg) {
 	switch(arrange) {
 		case COL:
 			if (align != LEFT && align != MIDDLE && align != RIGHT) {
-				log_warn("\nIgnoring invalid ALIGN %s for %s arrange. Valid values are LEFT, MIDDLE and RIGHT. Using default LEFT.", align_name(align), arrange_name(arrange));
+				log_warn("");
+				log_warn("Ignoring invalid ALIGN %s for %s arrange. Valid values are LEFT, MIDDLE and RIGHT. Using default LEFT.", align_name(align), arrange_name(arrange));
 				cfg->align = LEFT;
 			}
 			break;
 		case ROW:
 		default:
 			if (align != TOP && align != MIDDLE && align != BOTTOM) {
-				log_warn("\nIgnoring invalid ALIGN %s for %s arrange. Valid values are TOP, MIDDLE and BOTTOM. Using default TOP.", align_name(align), arrange_name(arrange));
+				log_warn("");
+				log_warn("Ignoring invalid ALIGN %s for %s arrange. Valid values are TOP, MIDDLE and BOTTOM. Using default TOP.", align_name(align), arrange_name(arrange));
 				cfg->align = TOP;
 			}
 			break;

--- a/src/client.c
+++ b/src/client.c
@@ -71,7 +71,7 @@ int client(struct IpcRequest *ipc_request) {
 
 	if (!ipc_request->yaml) {
 		log_debug("");
-log_debug("Client sending request: %s", ipc_command_friendly(ipc_request->command));
+		log_debug("Client sending request: %s", ipc_command_friendly(ipc_request->command));
 		print_cfg(DEBUG, ipc_request->cfg, ipc_request->command == CFG_DEL);
 	}
 

--- a/src/client.c
+++ b/src/client.c
@@ -70,7 +70,8 @@ int client(struct IpcRequest *ipc_request) {
 	}
 
 	if (!ipc_request->yaml) {
-		log_debug("\nClient sending request: %s", ipc_command_friendly(ipc_request->command));
+		log_debug("");
+log_debug("Client sending request: %s", ipc_command_friendly(ipc_request->command));
 		print_cfg(DEBUG, ipc_request->cfg, ipc_request->command == CFG_DEL);
 	}
 

--- a/src/displ.c
+++ b/src/displ.c
@@ -19,7 +19,8 @@ void displ_init(void) {
 	displ = calloc(1, sizeof(struct Displ));
 
 	if (!(displ->display = wl_display_connect(NULL))) {
-		log_fatal("\nUnable to connect to the compositor. Check or set the WAYLAND_DISPLAY environment variable. exiting");
+		log_fatal("");
+		log_fatal("Unable to connect to the compositor. Check or set the WAYLAND_DISPLAY environment variable. exiting");
 		wd_exit(EXIT_FAILURE);
 		return;
 	}
@@ -29,13 +30,15 @@ void displ_init(void) {
 	wl_registry_add_listener(displ->registry, registry_listener(), displ);
 
 	if (wl_display_roundtrip(displ->display) == -1) {
-		log_fatal("\nwl_display_roundtrip failed -1, exiting");
+		log_fatal("");
+		log_fatal("wl_display_roundtrip failed -1, exiting");
 		wd_exit_message(EXIT_FAILURE);
 		return;
 	}
 
 	if (!displ->zwlr_output_manager) {
-		log_fatal("\ncompositor does not support WLR output manager protocol, exiting");
+		log_fatal("");
+		log_fatal("compositor does not support WLR output manager protocol, exiting");
 		wd_exit(EXIT_FAILURE);
 		return;
 	}

--- a/src/fds.c
+++ b/src/fds.c
@@ -55,7 +55,8 @@ void fd_wd_cfg_dir_create(void) {
 	if ((wd_cfg_dir = inotify_add_watch(fd_cfg_dir, cfg->dir_path, IN_CLOSE_WRITE)) == -1) {
 		close(fd_cfg_dir);
 		fd_cfg_dir = -1;
-		log_fatal_errno("\nunable to create config directory watch for %s, exiting", cfg->dir_path);
+		log_fatal_errno("");
+		log_fatal_errno("unable to create config directory watch for %s, exiting", cfg->dir_path);
 		wd_exit_message(EXIT_FAILURE);
 		return;
 	}
@@ -69,11 +70,13 @@ void fd_wd_cfg_dir_destroy(void) {
 	}
 
 	if (inotify_rm_watch(fd_cfg_dir, wd_cfg_dir) == -1) {
-		log_error_errno("\nunable to remove config directory watch");
+		log_error_errno("");
+		log_error_errno("unable to remove config directory watch");
 	}
 
 	if (close(fd_cfg_dir) == -1) {
-		log_error_errno("\nunable to close config directory watch");
+		log_error_errno("");
+		log_error_errno("unable to close config directory watch");
 	}
 
 	fd_cfg_dir = -1;

--- a/src/fs.c
+++ b/src/fs.c
@@ -28,7 +28,8 @@ bool mkdir_p(char *path, mode_t mode) {
 	}
 
 	if (mkdir(path, mode) != 0) {
-		log_error_errno("\nCannot create directory %s", path);
+		log_error_errno("");
+		log_error_errno("Cannot create directory %s", path);
 		goto end;
 	}
 
@@ -48,7 +49,8 @@ bool file_write(const char *path, const char *contents, const char *mode) {
 	FILE *f = fopen(path, mode);
 
 	if (!f) {
-		log_error_errno("\nUnable to write to %s", path);
+		log_error_errno("");
+		log_error_errno("Unable to write to %s", path);
 		return false;
 	}
 
@@ -59,7 +61,8 @@ bool file_write(const char *path, const char *contents, const char *mode) {
 	fflush(f);
 
 	if (fclose(f) != 0) {
-		log_error_errno("\nUnable to write to %s", path);
+		log_error_errno("");
+		log_error_errno("Unable to write to %s", path);
 		return false;
 	}
 

--- a/src/head.c
+++ b/src/head.c
@@ -176,7 +176,8 @@ wl_fixed_t head_get_fixed_scale(const struct Head * const head, const double sca
 	fixed_scale = round((double)fixed_scale / HEAD_WLFIXED_SCALING_BASE * b) \
 				  * ((double)HEAD_WLFIXED_SCALING_BASE / b);
 	if (fixed_scale != fixed_scale_before) {
-		log_debug("\n%s: Rounded scale %g to nearest multiple of 1/%d: %.03f", head_human(head), scale, b, wl_fixed_to_double(fixed_scale));
+		log_debug("");
+		log_debug("%s: Rounded scale %g to nearest multiple of 1/%d: %.03f", head_human(head), scale, b, wl_fixed_to_double(fixed_scale));
 	}
 
 	return fixed_scale;

--- a/src/head.c
+++ b/src/head.c
@@ -287,7 +287,8 @@ struct Mode *head_find_mode(struct Head * const head) {
 
 			char *um_str = info_user_mode_string(um);
 
-			log_warn("\n%s: No available mode for user MODE %s, falling back to preferred", head->name, um_str);
+			log_warn("");
+			log_warn("%s: No available mode for user MODE %s, falling back to preferred", head->name, um_str);
 
 			char *human = sprintf_alloc("%s\n  No available mode for user MODE %s, falling back to preferred", head_human(head), um_str);
 

--- a/src/head.c
+++ b/src/head.c
@@ -251,14 +251,16 @@ void head_set_scaled_dimensions(struct Head * const head) {
 void head_apply_toggles(struct Head * const head, struct Cfg* cfg) {
 	if (slist_find_equal(cfg->disabled, head_disabled_matches_head, head) != NULL) {
 		if (head->overrided_enabled == NoOverride) {
-			log_info("\nApplying \"DISABLED\" override for %s", head->name);
+			log_info("");
+			log_info("Applying \"DISABLED\" override for %s", head->name);
 			if (head->current.enabled) {
 				head->overrided_enabled = OverrideFalse;
 			} else {
 				head->overrided_enabled = OverrideTrue;
 			}
 		} else {
-			log_info("\nResetting \"DISABLED\" override for %s", head->name);
+			log_info("");
+			log_info("Resetting \"DISABLED\" override for %s", head->name);
 			head->overrided_enabled = NoOverride;
 		}
 	}
@@ -306,7 +308,8 @@ struct Mode *head_find_mode(struct Head * const head) {
 		if (!mode && !head->warned_no_preferred) {
 			head->warned_no_preferred = true;
 
-			log_info("\n%s: No preferred mode, falling back to maximum available", head_human(head));
+			log_info("");
+			log_info("%s: No preferred mode, falling back to maximum available", head_human(head));
 
 			char *human = sprintf_alloc("%s\n  No preferred mode, falling back to maximum available", head_human(head));
 

--- a/src/head.c
+++ b/src/head.c
@@ -271,7 +271,8 @@ struct Mode *head_find_mode(struct Head * const head) {
 		return NULL;
 
 	if (slist_length(head->modes) == slist_length(head->modes_failed)) {
-		log_error("\nNo mode for %s, disabling.", head->name);
+		log_error("");
+		log_error("No mode for %s, disabling.", head->name);
 		call_back(ERROR, head_human(head), "\n  No mode, disabling");
 		return NULL;
 	}
@@ -326,7 +327,8 @@ struct Mode *head_find_mode(struct Head * const head) {
 	}
 
 	if (!mode) {
-		log_error("\nNo mode for %s, disabling.", head_human(head));
+		log_error("");
+		log_error("No mode for %s, disabling.", head_human(head));
 		call_back(ERROR, head_human(head), "\n  No mode, disabling");
 	}
 

--- a/src/info.c
+++ b/src/info.c
@@ -239,7 +239,8 @@ void print_cfg_commands(const enum LogThreshold t, const struct Cfg * const cfg)
 	bool newline;
 
 	if (cfg->align && cfg->arrange) {
-		log_(t, "\nway-displays -s ARRANGE_ALIGN %s %s", arrange_name(cfg->arrange), align_name(cfg->align));
+		log_(t, "");
+		log_(t, "way-displays -s ARRANGE_ALIGN %s %s", arrange_name(cfg->arrange), align_name(cfg->align));
 	}
 
 	if (cfg->order_name_desc) {
@@ -249,17 +250,20 @@ void print_cfg_commands(const enum LogThreshold t, const struct Cfg * const cfg)
 			msg = sprintf_append(msg, "'%s' ", (char*)i->val);
 		}
 
-		log_(t, "\nway-displays -s ORDER %s", msg);
+		log_(t, "");
+		log_(t, "way-displays -s ORDER %s", msg);
 
 		free(msg);
 	}
 
 	if (cfg->scaling) {
-		log_(t, "\nway-displays -s SCALING %s", on_off_name(cfg->scaling));
+		log_(t, "");
+		log_(t, "way-displays -s SCALING %s", on_off_name(cfg->scaling));
 	}
 
 	if (cfg->auto_scale) {
-		log_(t, "\nway-displays -s AUTO_SCALE %s", on_off_name(cfg->auto_scale));
+		log_(t, "");
+		log_(t, "way-displays -s AUTO_SCALE %s", on_off_name(cfg->auto_scale));
 	}
 
 	newline = true;
@@ -418,7 +422,8 @@ void print_head(const enum LogThreshold t, const enum InfoEvent event, const str
 	switch (event) {
 		case ARRIVED:
 		case NONE:
-			log_(t, "\n%s%s:", head->name ? head->name : "???", event == ARRIVED ? " Arrived" : "");
+			log_(t, "");
+			log_(t, "%s%s:", head->name ? head->name : "???", event == ARRIVED ? " Arrived" : "");
 			log_(t, "  info:");
 			if (head->name)
 				log_(t, "    name:      '%s'", head->name);
@@ -446,7 +451,8 @@ void print_head(const enum LogThreshold t, const enum InfoEvent event, const str
 			print_head_current(t, head);
 			break;
 		case DEPARTED:
-			log_(t, "\n%s Departed:", head->name);
+			log_(t, "");
+			log_(t, "%s Departed:", head->name);
 			if (head->name)
 				log_(t, "    name:      '%s'", head->name);
 			if (head->description)
@@ -454,7 +460,8 @@ void print_head(const enum LogThreshold t, const enum InfoEvent event, const str
 			break;
 		case DELTA:
 			if (head_current_not_desired(head)) {
-				log_(t, "\n%s Changing:", head->name);
+				log_(t, "");
+				log_(t, "%s Changing:", head->name);
 				log_(t, "  from:");
 				print_head_current(t, head);
 				log_(t, "  to:");
@@ -508,7 +515,8 @@ void print_adaptive_sync_fail(const enum LogThreshold t, const struct Head * con
 		return;
 	}
 
-	log_(t, "\n%s:", head_human(head));
+	log_(t, "");
+	log_(t, "%s:", head_human(head));
 	log_(t, "  Cannot enable VRR: this display or compositor may not support it.");
 	log_(t, "  To speed things up you can disable VRR for this display by adding the following or similar to your cfg.yaml");
 	log_(t, "  VRR_OFF:");
@@ -516,7 +524,8 @@ void print_adaptive_sync_fail(const enum LogThreshold t, const struct Head * con
 }
 
 void print_mode_fail(const enum LogThreshold t, const struct Head * const head, const struct Mode * const mode) {
-	log_(t, "\nChanges failed");
+	log_(t, "");
+	log_(t, "Changes failed");
 
 	if (!head) {
 		return;

--- a/src/info.c
+++ b/src/info.c
@@ -636,7 +636,8 @@ void call_back(const enum LogThreshold t, const char * const msg1, const char * 
 		return;
 	}
 
-	log_info("\nExecuting CALLBACK_CMD:");
+	log_info("");
+	log_info("Executing CALLBACK_CMD:");
 	log_info("  %s", cfg->callback_cmd);
 
 	// decorate human message and optional log

--- a/src/layout.c
+++ b/src/layout.c
@@ -442,7 +442,8 @@ void handle_failure(void) {
 
 			break;
 		default:
-			log_fatal("\nChanges failed, exiting");
+			log_fatal("");
+			log_fatal("Changes failed, exiting");
 			call_back(FATAL, displ->delta.human, "\nChanges failed, exiting");
 
 			wd_exit_message(EXIT_FAILURE);

--- a/src/layout.c
+++ b/src/layout.c
@@ -405,10 +405,12 @@ void handle_success(void) {
 static bool handle_cancelled(void) {
 	cancellation_retries++;
 	if (cancellation_retries <= MAX_CANCELLATION_RETRIES) {
-		log_warn("\nChanges cancelled, retrying (attempt %i)", cancellation_retries);
+		log_warn("");
+		log_warn("Changes cancelled, retrying (attempt %i)", cancellation_retries);
 		return true;
 	} else {
-		log_warn("\nChanges cancelled, max number of retry attempts exceeded");
+		log_warn("");
+		log_warn("Changes cancelled, max number of retry attempts exceeded");
 		return false;
 	}
 }

--- a/src/layout.c
+++ b/src/layout.c
@@ -395,7 +395,8 @@ void handle_success(void) {
 			break;
 	}
 
-	log_info("\nChanges successful");
+	log_info("");
+	log_info("Changes successful");
 	call_back(INFO, displ->delta.human ? displ->delta.human : "Changes successful", NULL);
 
 	displ_delta_destroy();

--- a/src/lid.c
+++ b/src/lid.c
@@ -114,13 +114,15 @@ static struct libinput *create_libinput_monitor(char *device_path) {
 
 	struct libinput *libinput_context = libinput_path_create_context(&libinput_impl, NULL);
 	if (!libinput_context) {
-		log_error("\nunable to create libinput monitoring context, abandoning laptop lid detection");
+		log_error("");
+		log_error("unable to create libinput monitoring context, abandoning laptop lid detection");
 		return NULL;
 	}
 
 	struct libinput_device *device = libinput_path_add_device(libinput_context, device_path);
 	if (!device) {
-		log_error("\nunable to add libinput path device %s, abandoning laptop lid detection", device_path);
+		log_error("");
+		log_error("unable to add libinput path device %s, abandoning laptop lid detection", device_path);
 		return NULL;
 	}
 

--- a/src/lid.c
+++ b/src/lid.c
@@ -174,7 +174,8 @@ void lid_update(void) {
 		libinput_dispatch(lid->libinput_monitor);
 	}
 
-	log_info("\nLid %s", lid->closed ? "closed" : "open");
+	log_info("");
+	log_info("Lid %s", lid->closed ? "closed" : "open");
 }
 
 void lid_init(void) {
@@ -204,7 +205,8 @@ void lid_init(void) {
 		return;
 	}
 
-	log_info("\nMonitoring lid device: %s", device_path);
+	log_info("");
+	log_info("Monitoring lid device: %s", device_path);
 
 	lid = calloc(1, sizeof(struct Lid));
 	lid->device_path = device_path;

--- a/src/lid.c
+++ b/src/lid.c
@@ -24,7 +24,8 @@ static int libinput_open_restricted(const char *path, int flags, void *data) {
 	int fd = open(path, flags);
 
 	if (fd <= 0) {
-		log_warn_errno("\nlibinput open %s failed", path);
+		log_warn_errno("");
+		log_warn_errno("libinput open %s failed", path);
 		return -errno;
 	}
 
@@ -34,7 +35,8 @@ static int libinput_open_restricted(const char *path, int flags, void *data) {
 static void libinput_close_restricted(int fd, void *data) {
 
 	if (close(fd) != 0) {
-		log_warn_errno("\nlibinput close failed");
+		log_warn_errno("");
+		log_warn_errno("libinput close failed");
 	}
 }
 

--- a/src/lid.c
+++ b/src/lid.c
@@ -48,13 +48,15 @@ static struct libinput *create_libinput_discovery(void) {
 
 	struct udev *udev = udev_new();
 	if (!udev) {
-		log_warn("\nunable to create udev context, abandoning laptop lid detection");
+		log_warn("");
+		log_warn("unable to create udev context, abandoning laptop lid detection");
 		return NULL;
 	}
 
 	libinput = libinput_udev_create_context(&libinput_impl, NULL, udev);
 	if (!libinput) {
-		log_warn("\nunable to create libinput discovery context, abandoning laptop lid detection");
+		log_warn("");
+		log_warn("unable to create libinput discovery context, abandoning laptop lid detection");
 		return NULL;
 	}
 
@@ -66,7 +68,8 @@ static struct libinput *create_libinput_discovery(void) {
 	}
 
 	if (libinput_udev_assign_seat(libinput, xdg_seat) != 0) {
-		log_warn("\nfailed to assign seat to libinput, abandoning laptop lid detection");
+		log_warn("");
+		log_warn("failed to assign seat to libinput, abandoning laptop lid detection");
 		return NULL;
 	}
 

--- a/src/listener_registry.c
+++ b/src/listener_registry.c
@@ -68,7 +68,8 @@ static void global(void *data,
 	} else if (strcmp(interface, wl_output_interface.name) == 0) {
 		bind_wl_output(data, wl_registry, name, interface, version);
 	} else if (strcmp(interface, wp_fractional_scale_manager_v1_interface.name) == 0) {
-		log_debug("\nCompositor supports %s version %d", interface, version);
+		log_debug("");
+		log_debug("Compositor supports %s version %d", interface, version);
 	}
 }
 

--- a/src/listener_registry.c
+++ b/src/listener_registry.c
@@ -82,7 +82,8 @@ static void global_remove(void *data,
 
 	// a "who cares?" situation in the WLR examples
 	if (displ && displ->zwlr_output_manager_name == name) {
-		log_info("\nDisplay's output manager has been removed, exiting");
+		log_info("");
+		log_info("Display's output manager has been removed, exiting");
 		wd_exit(EXIT_SUCCESS);
 	}
 }

--- a/src/listener_zwlr_output_mode.c
+++ b/src/listener_zwlr_output_mode.c
@@ -44,9 +44,11 @@ static void preferred(void *data,
 			char *mode_str = info_mode_string(mode);
 
 			if (mode_preferred->head && mode_preferred->head->name) {
-				log_info("\n%s: multiple preferred modes advertised: using initial %s, ignoring %s", mode_preferred->head->name, mode_preferred_str, mode_str);
+				log_info("");
+				log_info("%s: multiple preferred modes advertised: using initial %s, ignoring %s", mode_preferred->head->name, mode_preferred_str, mode_str);
 			} else {
-				log_info("\n???: multiple preferred modes advertised: using initial %s, ignoring %s", mode_preferred_str, mode_str);
+				log_info("");
+				log_info("???: multiple preferred modes advertised: using initial %s, ignoring %s", mode_preferred_str, mode_str);
 			}
 
 			free(mode_preferred_str);

--- a/src/log.c
+++ b/src/log.c
@@ -5,13 +5,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/param.h>
 #include <time.h>
 
 #include "log.h"
 
 #include "slist.h"
 
-#define LS 16384
+#define MAX_LINE_LEN 16384
 
 struct LogActive {
 	enum LogThreshold threshold;
@@ -98,7 +99,7 @@ static void log_line(const enum LogThreshold threshold, const int eno, const cha
 
 	// allocate the line for output and capture
 	if (__format && __args)
-		l = vsprintf_alloc(__format, __args);
+		l = vsnprintf_alloc(MAX_LINE_LEN, __format, __args);
 	else
 		l = strdup("");
 
@@ -252,6 +253,24 @@ char *vsprintf_alloc(const char *__restrict __format, va_list __args) {
 	va_copy(args, __args);
 	size_t len = vsnprintf(NULL, 0, __format, args);
 	va_end(args);
+
+	char *str = calloc(len + 1, sizeof(char));
+
+	va_copy(args, __args);
+	vsnprintf(str, len + 1, __format, args);
+	va_end(args);
+
+	return str;
+}
+
+char *vsnprintf_alloc(size_t __maxlen, const char *__restrict __format, va_list __args) {
+
+	va_list args;
+	va_copy(args, __args);
+	size_t raw = vsnprintf(NULL, 0, __format, args);
+	va_end(args);
+
+	size_t len = MIN(raw, __maxlen);
 
 	char *str = calloc(len + 1, sizeof(char));
 

--- a/src/log.c
+++ b/src/log.c
@@ -1,4 +1,3 @@
-#include <assert.h>
 #include <errno.h>
 #include <stdarg.h>
 #include <stdbool.h>

--- a/src/log.c
+++ b/src/log.c
@@ -84,7 +84,7 @@ static void print_line(const enum LogThreshold threshold, const char *l) {
 	if (isatty(fd))
 		colour = threshold_colours[threshold];
 
-	// colour for entire line
+	// maybe colour for entire line
 	if (colour)
 		fprintf(stream, "%s", colour);
 

--- a/src/log.c
+++ b/src/log.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <errno.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -27,6 +28,7 @@ struct LogActive active = {
 
 struct SList *log_cap_lines_active = NULL;
 
+// all thresholds, start of line
 char threshold_char[] = {
 	'?',
 	'D',
@@ -36,84 +38,83 @@ char threshold_char[] = {
 	'F',
 };
 
-char *threshold_prefix[] = {
-	"",
-	"",
-	"",
+// not for all thresholds
+char *threshold_label[] = {
+	NULL,
+	NULL,
+	NULL,
 	"WARNING: ",
 	"ERROR: ",
 	"FATAL: ",
 };
 
-static void print_time(enum LogThreshold threshold, FILE *__restrict __stream) {
-	static char buf[16];
-	static time_t t;
-
-	t = time(NULL);
-
-	strftime(buf, sizeof(buf), "%H:%M:%S", localtime(&t));
-
-	fprintf(__stream, "%c [%s] ", threshold_char[threshold], buf);
-}
-
-static void capture_line(struct SList **lines, enum LogThreshold threshold, char *l) {
-	struct LogCapLine *line = calloc(1, sizeof(struct LogCapLine));
-	line->line = strdup(l);
-	line->threshold = threshold;
-	slist_append(lines, line);
-}
-
-static void print_raw(enum LogThreshold threshold, bool prefix, const char *l) {
-	static FILE *stream;
-
-	stream = threshold >= ERROR ? stderr : stdout;
-
-	if (threshold >= active.threshold && !active.suppressing) {
-		if (active.times) {
-			print_time(threshold, stream);
-		}
-		if (l[0] != '\0') {
-			fprintf(stream, "%s%s\n", prefix ? threshold_prefix[threshold] : "", l);
-		} else {
-			fprintf(stream, "\n");
-		}
-	}
-}
-
-static void print_line(enum LogThreshold threshold, bool prefix, int eno, const char *__restrict __format, va_list __args) {
-	static char l[LS];
-	static size_t n;
-
-	n = 0;
-	l[0] = '\0';
-
-	if (__format) {
-		n += vsnprintf(l + n, LS - n, __format, __args);
-	}
-	if (eno) {
-		n += snprintf(l + n, LS - n, ": %d %s", eno, strerror(eno));
-	}
-
-	if (n >= LS) {
-		sprintf(l + LS - 4, "...");
-	}
-
+static void capture_line(enum LogThreshold threshold, char *l) {
 	for (struct SList *i = log_cap_lines_active; i; i = i->nex) {
-		capture_line(i->val, threshold, l);
-	}
+		struct LogCapLine *line = calloc(1, sizeof(struct LogCapLine));
+		line->line = strdup(l);
+		line->threshold = threshold;
 
-	print_raw(threshold, prefix, l);
+		slist_append(i->val, line);
+	}
 }
 
-static void print_log(enum LogThreshold threshold, int eno, const char *__restrict __format, va_list __args) {
-	static const char *format;
+static void print_line(const enum LogThreshold threshold, const char *l) {
+	static char buf_time[16];
 
-	format = __format;
-	while (*format == '\n') {
-		print_line(threshold, false, 0, NULL, __args);
-		format++;
+	if (threshold < active.threshold || active.suppressing)
+		return;
+
+	FILE *stream = threshold >= ERROR ? stderr : stdout;
+
+	// maybe one char threshold and time
+	if (active.times) {
+
+		time_t t = time(NULL);
+
+		strftime(buf_time, sizeof(buf_time), "%H:%M:%S", localtime(&t));
+
+		fprintf(stream, "%c [%s] ", threshold_char[threshold], buf_time);
 	}
-	print_line(threshold, true, eno, format, __args);
+
+	if (l) {
+		// maybe label on non-empty lines
+		if (l[0] != '\0' && threshold_label[threshold]) {
+			fprintf(stream, "%s", threshold_label[threshold]);
+		}
+
+		// line contents
+		fprintf(stream, "%s\n", l);
+	} else {
+
+		// empty line
+		fprintf(stream, "\n");
+	}
+}
+
+// allocate a buffer containing the line's content, maybe printing and capturing
+// allocating the buffer is slower than direct vfprintf, however it is the safer way to capture
+static void log_line(const enum LogThreshold threshold, const int eno, const char *__restrict __format, va_list __args) {
+	char *l;
+
+	// allocate the line for output and capture
+	if (__format && __args)
+		l = vsprintf_alloc(__format, __args);
+	else
+		l = strdup("");
+
+	// append errno
+	if (eno)
+		l = sprintf_append(l, ": %d %s", eno, strerror(eno));
+
+
+	// output depending on threshold
+	print_line(threshold, l);
+
+	// capture content regardless of threshold
+	if (log_cap_lines_active)
+		capture_line(threshold, l);
+
+	free(l);
 }
 
 void log_set_threshold(enum LogThreshold threshold, bool cli) {
@@ -138,63 +139,63 @@ void log_set_times(bool times) {
 void log_(enum LogThreshold threshold, const char *__restrict __format, ...) {
 	va_list args;
 	va_start(args, __format);
-	print_log(threshold, 0, __format, args);
+	log_line(threshold, 0, __format, args);
 	va_end(args);
 }
 
 void log_debug(const char *__restrict __format, ...) {
 	va_list args;
 	va_start(args, __format);
-	print_log(DEBUG, 0, __format, args);
+	log_line(DEBUG, 0, __format, args);
 	va_end(args);
 }
 
 void log_info(const char *__restrict __format, ...) {
 	va_list args;
 	va_start(args, __format);
-	print_log(INFO, 0, __format, args);
+	log_line(INFO, 0, __format, args);
 	va_end(args);
 }
 
 void log_warn(const char *__restrict __format, ...) {
 	va_list args;
 	va_start(args, __format);
-	print_log(WARNING, 0, __format, args);
+	log_line(WARNING, 0, __format, args);
 	va_end(args);
 }
 
 void log_warn_errno(const char *__restrict __format, ...) {
 	va_list args;
 	va_start(args, __format);
-	print_log(WARNING, errno, __format, args);
+	log_line(WARNING, errno, __format, args);
 	va_end(args);
 }
 
 void log_error(const char *__restrict __format, ...) {
 	va_list args;
 	va_start(args, __format);
-	print_log(ERROR, 0, __format, args);
+	log_line(ERROR, 0, __format, args);
 	va_end(args);
 }
 
 void log_error_errno(const char *__restrict __format, ...) {
 	va_list args;
 	va_start(args, __format);
-	print_log(ERROR, errno, __format, args);
+	log_line(ERROR, errno, __format, args);
 	va_end(args);
 }
 
 void log_fatal(const char *__restrict __format, ...) {
 	va_list args;
 	va_start(args, __format);
-	print_log(FATAL, 0, __format, args);
+	log_line(FATAL, 0, __format, args);
 	va_end(args);
 }
 
 void log_fatal_errno(const char *__restrict __format, ...) {
 	va_list args;
 	va_start(args, __format);
-	print_log(FATAL, errno, __format, args);
+	log_line(FATAL, errno, __format, args);
 	va_end(args);
 }
 
@@ -229,7 +230,7 @@ void log_cap_lines_playback(struct SList *lines) {
 		if (!line)
 			continue;
 
-		print_raw(line->threshold, true, line->line);
+		print_line(line->threshold, line->line);
 	}
 }
 
@@ -243,6 +244,22 @@ void log_cap_lines_stop(struct SList **lines) {
 
 void log_cap_lines_free(struct SList **lines) {
 	slist_free_vals(lines, log_cap_line_free);
+}
+
+char *vsprintf_alloc(const char *__restrict __format, va_list __args) {
+
+	va_list args;
+	va_copy(args, __args);
+	size_t len = vsnprintf(NULL, 0, __format, args);
+	va_end(args);
+
+	char *str = calloc(len + 1, sizeof(char));
+
+	va_copy(args, __args);
+	vsnprintf(str, len + 1, __format, args);
+	va_end(args);
+
+	return str;
 }
 
 char *sprintf_alloc(const char *__restrict __format, ...) {

--- a/src/log.c
+++ b/src/log.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <sys/param.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "log.h"
 
@@ -19,17 +20,17 @@ struct LogActive {
 	bool times;
 	bool suppressing;
 };
-struct LogActive active = {
+static struct LogActive active = {
 	.threshold = LOG_THRESHOLD_DEFAULT,
 	.threshold_cli = false,
 	.times = false,
 	.suppressing = false,
 };
 
-struct SList *log_cap_lines_active = NULL;
+static struct SList *log_cap_lines_active = NULL;
 
 // all thresholds, start of line
-char threshold_char[] = {
+static const char threshold_char[] = {
 	'?',
 	'D',
 	'I',
@@ -39,7 +40,7 @@ char threshold_char[] = {
 };
 
 // not for all thresholds
-char *threshold_label[] = {
+static const char *threshold_label[] = {
 	NULL,
 	NULL,
 	NULL,
@@ -47,6 +48,17 @@ char *threshold_label[] = {
 	"ERROR: ",
 	"FATAL: ",
 };
+
+// all but info
+static const char *threshold_colours[] = {
+	NULL,
+	"\x1B[1;36m", // cyan    debug
+	NULL,         //         info
+	"\x1B[1;35m", // magenta warning
+	"\x1B[1;31m", // red     error
+	"\x1B[1;33m", // yellow  fatal
+};
+static const char reset_colour[] = "\x1B[0m";
 
 static void capture_line(enum LogThreshold threshold, char *l) {
 	for (struct SList *i = log_cap_lines_active; i; i = i->nex) {
@@ -65,6 +77,16 @@ static void print_line(const enum LogThreshold threshold, const char *l) {
 		return;
 
 	FILE *stream = threshold >= ERROR ? stderr : stdout;
+	const int fd = threshold >= ERROR ? STDERR_FILENO : STDOUT_FILENO;
+
+	// colour only for terminal output
+	const char *colour = NULL;
+	if (isatty(fd))
+		colour = threshold_colours[threshold];
+
+	// colour for entire line
+	if (colour)
+		fprintf(stream, "%s", colour);
 
 	// maybe one char threshold and time
 	if (active.times) {
@@ -77,17 +99,19 @@ static void print_line(const enum LogThreshold threshold, const char *l) {
 	}
 
 	if (l) {
+
 		// maybe label on non-empty lines
 		if (l[0] != '\0' && threshold_label[threshold]) {
 			fprintf(stream, "%s", threshold_label[threshold]);
 		}
 
 		// line contents
-		fprintf(stream, "%s\n", l);
+		fprintf(stream, "%s%s\n", l, colour ? reset_colour : "");
+
 	} else {
 
 		// empty line
-		fprintf(stream, "\n");
+		fprintf(stream, "%s\n", colour ? reset_colour : "");
 	}
 }
 

--- a/src/process.c
+++ b/src/process.c
@@ -56,7 +56,8 @@ void pid_file_create(void) {
 
 	pid_t pid = pid_active_server();
 	if (pid_active_server()) {
-		log_fatal("\nanother instance %d is running, exiting", pid);
+		log_fatal("");
+		log_fatal("another instance %d is running, exiting", pid);
 		wd_exit(EXIT_FAILURE);
 		return;
 	}
@@ -146,7 +147,8 @@ void wd_exit(const int __status) {
 }
 
 void wd_exit_message(const int __status) {
-	log_fatal("\nPlease raise an issue: https://github.com/alex-courtis/way-displays/issues");
+	log_fatal("");
+	log_fatal("Please raise an issue: https://github.com/alex-courtis/way-displays/issues");
 	log_fatal("Attach this log and describe the events that occurred before this failure.");
 	exit(__status);
 }

--- a/src/process.c
+++ b/src/process.c
@@ -65,7 +65,8 @@ void pid_file_create(void) {
 	// attempt to use existing, regardless of owner
 	int fd = open(path, O_RDWR | O_CLOEXEC);
 	if (fd == -1 && errno != ENOENT) {
-		log_fatal_errno("\nunable to open existing pid file for writing %s, exiting", path);
+		log_fatal_errno("");
+		log_fatal_errno("unable to open existing pid file for writing %s, exiting", path);
 		wd_exit_message(EXIT_FAILURE);
 		return;
 	}
@@ -76,7 +77,8 @@ void pid_file_create(void) {
 		fd = open(path, O_RDWR | O_CLOEXEC | O_CREAT, 0666);
 		umask(umask_prev);
 		if (fd == -1) {
-			log_fatal_errno("\nunable to create pid file %s, exiting", path);
+			log_fatal_errno("");
+			log_fatal_errno("unable to create pid file %s, exiting", path);
 			wd_exit_message(EXIT_FAILURE);
 			return;
 		}
@@ -84,21 +86,24 @@ void pid_file_create(void) {
 
 	// lock it forever
 	if (flock(fd, LOCK_EX | LOCK_NB) != 0) {
-		log_fatal_errno("\nunable to lock pid file %s, exiting", path);
+		log_fatal_errno("");
+		log_fatal_errno("unable to lock pid file %s, exiting", path);
 		wd_exit_message(EXIT_FAILURE);
 		return;
 	}
 
 	// clear it
 	if (ftruncate(fd, 0) == -1) {
-		log_fatal_errno("\nunable to truncate pid file %s, exiting", path);
+		log_fatal_errno("");
+		log_fatal_errno("unable to truncate pid file %s, exiting", path);
 		wd_exit_message(EXIT_FAILURE);
 		return;
 	}
 
 	// write the new pid
 	if (dprintf(fd, "%d", getpid()) <= 0) {
-		log_fatal_errno("\nunable to write to pid file %s, exiting", path);
+		log_fatal_errno("");
+		log_fatal_errno("unable to write to pid file %s, exiting", path);
 		wd_exit_message(EXIT_FAILURE);
 		return;
 	}
@@ -115,7 +120,8 @@ void spawn_sh_cmd(const char * const command, const struct STable * const env) {
 
 	pid_t pid = fork();
 	if (pid < 0) {
-		log_error_errno("\nfailed to fork");
+		log_error_errno("");
+		log_error_errno("failed to fork");
 		return;
 	}
 
@@ -136,7 +142,8 @@ void spawn_sh_cmd(const char * const command, const struct STable * const env) {
 
 		// execute command in the child process
 		execl("/bin/sh", "/bin/sh", "-c", command, (char *)NULL);
-		log_error_errno("\nfailed to execute /bin/sh");
+		log_error_errno("");
+		log_error_errno("failed to execute /bin/sh");
 		// exit the child process in case the exec fails
 		exit(-1);
 	}

--- a/src/server.c
+++ b/src/server.c
@@ -95,7 +95,8 @@ static void receive_ipc_request(int server_socket) {
 		goto send;
 	}
 
-	log_debug("\nServer received request: %s", ipc_command_friendly(ipc_request->command));
+	log_debug("");
+	log_debug("Server received request: %s", ipc_command_friendly(ipc_request->command));
 	if (ipc_request->cfg) {
 		print_cfg(DEBUG, ipc_request->cfg, ipc_request->command == CFG_DEL);
 	}

--- a/src/server.c
+++ b/src/server.c
@@ -33,7 +33,8 @@ struct IpcOperation *ipc_operation = NULL;
 static void handle_ipc_in_progress(int server_socket) {
 	struct IpcRequest *request = ipc_receive_request(server_socket);
 	if (!request) {
-		log_error("\nFailed to read IPC request");
+		log_error("");
+		log_error("Failed to read IPC request");
 		return;
 	}
 
@@ -77,7 +78,8 @@ static void receive_ipc_request(int server_socket) {
 
 	struct IpcRequest *ipc_request = ipc_receive_request(server_socket);
 	if (!ipc_request) {
-		log_error("\nFailed to read IPC request");
+		log_error("");
+		log_error("Failed to read IPC request");
 		log_cap_lines_stop(&ipc_operation->log_cap_lines);
 		ipc_operation_free(ipc_operation);
 		ipc_operation = NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -183,7 +183,8 @@ static int loop(void) {
 		// poll for all events
 		log_debug("LOOP poll");
 		if (poll(pfds, npfds, -1) < 0) {
-			log_fatal_errno("\npoll failed, exiting");
+			log_fatal_errno("");
+			log_fatal_errno("poll failed, exiting");
 			wd_exit_message(EXIT_FAILURE);
 			return EXIT_FAILURE;
 		}

--- a/src/server.c
+++ b/src/server.c
@@ -119,11 +119,13 @@ static void receive_ipc_request(int server_socket) {
 					ipc_operation->done = false;
 					cfg_free(cfg);
 					cfg = cfg_merged;
-					log_info("\nNew configuration:");
+					log_info("");
+					log_info("New configuration:");
 					print_cfg(INFO, cfg, false);
 				} else {
 					// complete
-					log_info("\nNo config changes to make.");
+					log_info("");
+					log_info("No config changes to make.");
 				}
 				break;
 			}
@@ -143,7 +145,8 @@ static void receive_ipc_request(int server_socket) {
 		default:
 			{
 				// complete
-				log_info("\nActive configuration:");
+				log_info("");
+				log_info("Active configuration:");
 				print_cfg(INFO, cfg, false);
 				print_cfg_commands(INFO, cfg);
 				print_heads(INFO, NONE, heads);
@@ -193,7 +196,8 @@ static int loop(void) {
 		_wl_display_dispatch_pending__read_events(displ->display, FL);
 
 		if (!displ->zwlr_output_manager) {
-			log_info("\nDisplay's output manager has departed, exiting");
+			log_info("");
+			log_info("Display's output manager has departed, exiting");
 			wd_exit(EXIT_SUCCESS);
 			return EXIT_SUCCESS;
 		}
@@ -205,7 +209,8 @@ static int loop(void) {
 			if (read(fd_signal, &fdsi, sizeof(fdsi)) == sizeof(fdsi)) {
 				log_debug("LOOP signal %d: %s", fdsi.ssi_signo, strsignal(fdsi.ssi_signo));
 				if (fdsi.ssi_signo != SIGPIPE) {
-					log_info("\nReceived signal %d: %s, exiting", fdsi.ssi_signo, strsignal(fdsi.ssi_signo));
+					log_info("");
+					log_info("Received signal %d: %s, exiting", fdsi.ssi_signo, strsignal(fdsi.ssi_signo));
 					return fdsi.ssi_signo;
 				}
 			}
@@ -273,7 +278,8 @@ void reload_cfg(void) {
 	if (!cfg || !cfg->file_path)
 		return;
 
-	log_info("\nReloading configuration file: %s", cfg->file_path);
+	log_info("");
+	log_info("Reloading configuration file: %s", cfg->file_path);
 
 	struct Cfg *cfg_loaded = yaml_unmarshal_file(cfg->file_path, yaml_root_to_cfg);
 
@@ -286,12 +292,14 @@ void reload_cfg(void) {
 
 		log_set_threshold(cfg->log_threshold, false);
 		validate_fix(cfg);
-		log_info("\nNew configuration:");
+		log_info("");
+		log_info("New configuration:");
 		print_cfg(INFO, cfg, false);
 		validate_warn(cfg);
 
 	} else {
-		log_info("\nConfiguration unchanged:");
+		log_info("");
+		log_info("Configuration unchanged:");
 		print_cfg(INFO, cfg, false);
 	}
 }
@@ -302,16 +310,19 @@ void load_cfg(void) {
 	bool resolved = cfg_resolve_file_path(cfg_resolved);
 
 	if (resolved) {
-		log_info("\nFound configuration file: %s", cfg_resolved->file_path);
+		log_info("");
+		log_info("Found configuration file: %s", cfg_resolved->file_path);
 
 		cfg = yaml_unmarshal_file(cfg_resolved->file_path, yaml_root_to_cfg);
 
 		if (!cfg) {
-			log_info("\nUsing default configuration:");
+			log_info("");
+			log_info("Using default configuration:");
 			cfg = cfg_init();
 		}
 	} else {
-		log_info("\nNo configuration file found, using defaults:");
+		log_info("");
+		log_info("No configuration file found, using defaults:");
 		cfg = cfg_init();
 	}
 
@@ -319,7 +330,8 @@ void load_cfg(void) {
 	cfg_copy_file_path(cfg_resolved, cfg);
 
 	validate_fix(cfg);
-	log_info("\nActive configuration:");
+	log_info("");
+	log_info("Active configuration:");
 	print_cfg(INFO, cfg, false);
 	validate_warn(cfg);
 

--- a/src/sockets.c
+++ b/src/sockets.c
@@ -47,7 +47,8 @@ char *socket_read(int socket_client) {
 	// peek, as the sender may experience delay between connecting and sending
 	if (recv(socket_client, NULL, 0, MSG_PEEK) == -1) {
 		if (errno == EAGAIN) {
-			log_error("\nSocket read timeout");
+			log_error("");
+			log_error("Socket read timeout");
 		} else {
 			log_error_errno("\nSocket recv failed");
 		}

--- a/src/sockets.c
+++ b/src/sockets.c
@@ -18,7 +18,8 @@
 static bool set_socket_timeout(int socket, struct timeval timeout) {
 
 	if (setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) == -1) {
-		log_error_errno("\nSocket set timeout failed");
+		log_error_errno("");
+		log_error_errno("Socket set timeout failed");
 		return false;
 	}
 
@@ -30,7 +31,8 @@ int socket_accept(int socket_server) {
 	int socket_client = accept(socket_server, NULL, NULL);
 
 	if (socket_client == -1) {
-		log_error_errno("\nSocket accept failed");
+		log_error_errno("");
+		log_error_errno("Socket accept failed");
 		return -1;
 	}
 
@@ -50,7 +52,8 @@ char *socket_read(int socket_client) {
 			log_error("");
 			log_error("Socket read timeout");
 		} else {
-			log_error_errno("\nSocket recv failed");
+			log_error_errno("");
+			log_error_errno("Socket recv failed");
 		}
 		return NULL;
 	}
@@ -58,7 +61,8 @@ char *socket_read(int socket_client) {
 	// total message size right now; further data will be disregarded
 	int n = 0;
 	if (ioctl(socket_client, FIONREAD, &n) == -1) {
-		log_error_errno("\nServer FIONREAD failed");
+		log_error_errno("");
+		log_error_errno("Server FIONREAD failed");
 		return NULL;
 	}
 	if (n == 0) {
@@ -68,7 +72,8 @@ char *socket_read(int socket_client) {
 	// read it
 	char *buf = calloc(n + 1, sizeof(char));
 	if (recv(socket_client, buf, n, 0) == -1) {
-		log_error_errno("\nSocket recv failed");
+		log_error_errno("");
+		log_error_errno("Socket recv failed");
 		return NULL;
 	}
 
@@ -78,7 +83,8 @@ char *socket_read(int socket_client) {
 ssize_t socket_write(int socket_client, char *data, size_t len) {
 	ssize_t n;
 	if ((n = write(socket_client, data, len)) == -1) {
-		log_error_errno("\nSocket write failed");
+		log_error_errno("");
+		log_error_errno("Socket write failed");
 		return -1;
 	}
 
@@ -105,7 +111,8 @@ void socket_path(struct sockaddr_un *addr) {
 int create_socket_server(void) {
 	int socket_server = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (socket_server == -1) {
-		log_error_errno("\nServer socket failed, clients unavailable");
+		log_error_errno("");
+		log_error_errno("Server socket failed, clients unavailable");
 		return -1;
 	}
 
@@ -115,13 +122,15 @@ int create_socket_server(void) {
 	unlink(addr.sun_path);
 
 	if (bind(socket_server, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
-		log_error_errno("\nServer socket bind failed, clients unavailable");
+		log_error_errno("");
+		log_error_errno("Server socket bind failed, clients unavailable");
 		close(socket_server);
 		return -1;
 	}
 
 	if (listen(socket_server, 3) < 0) {
-		log_error_errno("\nServer socket listen failed, clients unavailable");
+		log_error_errno("");
+		log_error_errno("Server socket listen failed, clients unavailable");
 		close(socket_server);
 		return -1;
 	}
@@ -138,7 +147,8 @@ int create_socket_server(void) {
 int create_socket_client(void) {
 	int socket_client = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (socket_client == -1) {
-		log_error_errno("\nSocket create failed");
+		log_error_errno("");
+		log_error_errno("Socket create failed");
 		return -1;
 	}
 
@@ -147,7 +157,8 @@ int create_socket_client(void) {
 	socket_path(&addr);
 
 	if (connect(socket_client, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
-		log_error_errno("\nSocket connect failed");
+		log_error_errno("");
+		log_error_errno("Socket connect failed");
 		close(socket_client);
 		return -1;
 	}

--- a/src/wl_wrappers.c
+++ b/src/wl_wrappers.c
@@ -13,7 +13,8 @@ int _wl_display_prepare_read(struct wl_display *display, char *file, int line) {
 
 	if ((ret = wl_display_prepare_read(display)) == -1) {
 		if (errno != EAGAIN) {
-			log_fatal_errno("\nwl_display_prepare_read failed at %s:%d, exiting", file, line);
+			log_fatal_errno("");
+			log_fatal_errno("wl_display_prepare_read failed at %s:%d, exiting", file, line);
 			wd_exit_message(EXIT_FAILURE);
 		}
 	}
@@ -25,7 +26,8 @@ int _wl_display_dispatch_pending__read_events(struct wl_display *display, char *
 	static int ret;
 
 	if ((ret = wl_display_dispatch_pending(display)) == -1) {
-		log_fatal_errno("\nwl_display_dispatch_pending for read_events failed at %s:%d, exiting", file, line);
+		log_fatal_errno("");
+		log_fatal_errno("wl_display_dispatch_pending for read_events failed at %s:%d, exiting", file, line);
 		wd_exit_message(EXIT_FAILURE);
 	}
 
@@ -36,7 +38,8 @@ int _wl_display_dispatch_pending__prepare_read(struct wl_display *display, char 
 	static int ret;
 
 	if ((ret = wl_display_dispatch_pending(display)) == -1) {
-		log_fatal_errno("\nwl_display_dispatch_pending for prepare_read failed at %s:%d, exiting", file, line);
+		log_fatal_errno("");
+		log_fatal_errno("wl_display_dispatch_pending for prepare_read failed at %s:%d, exiting", file, line);
 		wd_exit_message(EXIT_FAILURE);
 	}
 
@@ -47,7 +50,8 @@ int _wl_display_flush(struct wl_display *display, char *file, int line) {
 	static int ret;
 
 	if ((ret = wl_display_flush(display)) == -1) {
-		log_fatal_errno("\nwl_display_flush failed at %s:%d, exiting", file, line);
+		log_fatal_errno("");
+		log_fatal_errno("wl_display_flush failed at %s:%d, exiting", file, line);
 		wd_exit_message(EXIT_FAILURE);
 	}
 
@@ -62,7 +66,8 @@ int _wl_display_read_events(struct wl_display *display, char *file, int line) {
 			log_info("");
 			log_info("Wayland display terminated, exiting.");
 		} else {
-			log_fatal_errno("\nwl_display_read_events failed at %s:%d, exiting", file, line);
+			log_fatal_errno("");
+			log_fatal_errno("wl_display_read_events failed at %s:%d, exiting", file, line);
 			wd_exit_message(EXIT_FAILURE);
 		}
 	}

--- a/src/wl_wrappers.c
+++ b/src/wl_wrappers.c
@@ -59,7 +59,8 @@ int _wl_display_read_events(struct wl_display *display, char *file, int line) {
 
 	if ((ret = wl_display_read_events(display)) == -1) {
 		if (errno == EPIPE) {
-			log_info("\nWayland display terminated, exiting.");
+			log_info("");
+			log_info("Wayland display terminated, exiting.");
 		} else {
 			log_fatal_errno("\nwl_display_read_events failed at %s:%d, exiting", file, line);
 			wd_exit_message(EXIT_FAILURE);


### PR DESCRIPTION
fixes #243

- log strings are rendered in a safer but slower manner, allocating each line instead of using the static buffer
- extra blank log lines for leading `\n` have been removed
- blank log lines have been explicitly added in all places they are needed
- colours added when outputting to console