### PR TITLE
feat(#114): add LID condition for DISABLED

### DIFF
--- a/examples/cfg.yaml
+++ b/examples/cfg.yaml
@@ -118,7 +118,7 @@ LOG_THRESHOLD: INFO
 ## In this example:
 ##  HDMI-1 will always be disabled
 ##  eDP-1 will be disabled only if both DP-1 and DP-2 are plugged.
-##  DP-3 will be disabled only when the lid is open
+##  DP-3 will be disabled when the lid is open or HDMI-2 is plugged
 # DISABLED:
 #   - 'HDMI-1'
 #   - NAME_DESC: 'eDP-1'
@@ -129,3 +129,7 @@ LOG_THRESHOLD: INFO
 #   - NAME_DESC: 'DP-3'
 #     IF:
 #       - LID: OPEN
+#   - NAME_DESC: 'DP-3'
+#     IF:
+#       - PLUGGED:
+#           - 'HDMI-2'

--- a/examples/cfg.yaml
+++ b/examples/cfg.yaml
@@ -115,8 +115,10 @@ LOG_THRESHOLD: INFO
 ## Disable the specified displays.
 ## Resulting state of a display is equal to OR of all matching conditions, so
 ## explicit disabled without `IF` will override any conditions for the display.
-## In this example, HDMI-1 will always be disabled, and eDP-1 will be disabled
-## only if both DP-1 and DP-2 are plugged.
+## In this example:
+##  HDMI-1 will always be disabled
+##  eDP-1 will be disabled only if both DP-1 and DP-2 are plugged.
+##  DP-3 will be disabled only when the lid is open
 # DISABLED:
 #   - 'HDMI-1'
 #   - NAME_DESC: 'eDP-1'
@@ -124,3 +126,6 @@ LOG_THRESHOLD: INFO
 #       - PLUGGED:
 #           - '!^DP-1$'
 #           - '!^DP-2$'
+#   - NAME_DESC: 'DP-3'
+#     IF:
+#       - LID: OPEN

--- a/inc/cfg.h
+++ b/inc/cfg.h
@@ -72,7 +72,7 @@ struct Disabled {
 
 #define CALLBACK_CMD_DEFAULT "notify-send \"way-displays ${CALLBACK_LEVEL}\" \"${CALLBACK_MSG}\""
 
-#define COMMENT_YAML_SCHEMA "# yaml-language-server: $schema=https://raw.githubusercontent.com/alex-courtis/way-displays/refs/heads/master/schema/cfg-1.1.0.yaml"
+#define COMMENT_YAML_SCHEMA "# yaml-language-server: $schema=https://raw.githubusercontent.com/alex-courtis/way-displays/refs/heads/master/schema/cfg-1.2.0.yaml"
 
 struct Cfg {
 	char *dir_path;

--- a/inc/conditions.h
+++ b/inc/conditions.h
@@ -5,8 +5,9 @@
 #include "slist.h"
 
 enum ConditionLid {
-	CLOSED = 1,
-	OPEN,
+	LID_CLOSED = 1,
+	LID_OPEN,
+	LID_NOT_PRESENT,
 };
 
 struct Condition {

--- a/inc/conditions.h
+++ b/inc/conditions.h
@@ -4,10 +4,15 @@
 #include <stdbool.h>
 #include "slist.h"
 
+enum ConditionLid {
+	CLOSED = 1,
+	OPEN,
+};
 
 struct Condition {
 	struct SList *plugged;
 	struct SList *unplugged;
+	enum ConditionLid lid;
 };
 
 void condition_free(const void *data);

--- a/inc/convert.h
+++ b/inc/convert.h
@@ -4,6 +4,7 @@
 #include <wayland-client-protocol.h>
 
 #include "cfg.h"
+#include "conditions.h"
 #include "displ.h"
 #include "ipc.h"
 #include "log.h"
@@ -52,6 +53,10 @@ char *log_threshold_names(void);
 
 enum DisplState displ_state_val(const char *name);
 const char *displ_state_name(enum DisplState displ_state);
+
+enum ConditionLid condition_lid_val(const char *name);
+const char *condition_lid_name(enum ConditionLid condition_lid);
+char *condition_lid_names(void);
 
 enum ScaleRoundStrategy scale_round_strategy_val(const char *name);
 const char *scale_round_strategy_name(enum ScaleRoundStrategy scale_round_strategy);

--- a/schema/cfg-1.2.0.yaml
+++ b/schema/cfg-1.2.0.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
 
 $schema: https://json-schema.org/draft/2020-12/schema
-$id: https://raw.githubusercontent.com/alex-courtis/way-displays/refs/heads/master/schema/cfg-1.1.0.yaml
+$id: https://raw.githubusercontent.com/alex-courtis/way-displays/refs/heads/master/schema/cfg-1.2.0.yaml
 
 title: way-displays cfg
 description: |-
@@ -17,7 +17,7 @@ properties:
     default: ROW
 
   ALIGN:
-    $ref: 'types-1.1.0.yaml#/$defs/align'
+    $ref: 'types-1.2.0.yaml#/$defs/align'
     default: TOP
 
   ORDER:
@@ -27,7 +27,7 @@ properties:
       COLUMN is top to bottom.
       ORDER defaults to the order in which displays are discovered.
     items:
-      $ref: 'types-1.1.0.yaml#/$defs/fuzzy_display_match'
+      $ref: 'types-1.2.0.yaml#/$defs/fuzzy_display_match'
 
   SCALING:
     type: boolean
@@ -78,7 +78,7 @@ properties:
     description: |-
       Auto scale may be overridden for each display.
     items:
-      $ref: 'types-1.1.0.yaml#/$defs/scale'
+      $ref: 'types-1.2.0.yaml#/$defs/scale'
 
   MODE:
     type: array
@@ -86,21 +86,21 @@ properties:
       Override the preferred mode.
       WARNING: this may result in an unusable display. See https://github.com/alex-courtis/way-displays#known-issues-with-workarounds
     items:
-      $ref: 'types-1.1.0.yaml#/$defs/mode'
+      $ref: 'types-1.2.0.yaml#/$defs/mode'
 
   TRANSFORM:
     type: array
     description: |-
       Rotate or translate the display.
     items:
-      $ref: 'types-1.1.0.yaml#/$defs/transform'
+      $ref: 'types-1.2.0.yaml#/$defs/transform'
 
   VRR_OFF:
     type: array
     description: |-
       VRR / adaptive sync is enabled by default. Disable it per display.
     items:
-      $ref: 'types-1.1.0.yaml#/$defs/fuzzy_display_match'
+      $ref: 'types-1.2.0.yaml#/$defs/fuzzy_display_match'
 
   CALLBACK_CMD:
     type: string
@@ -124,7 +124,7 @@ properties:
       Enable laptop lid detection.
 
   LOG_THRESHOLD:
-    $ref: 'types-1.1.0.yaml#/$defs/log_threshold'
+    $ref: 'types-1.2.0.yaml#/$defs/log_threshold'
     default: INFO
     description: |-
       Applies to logs and callbacks.
@@ -134,6 +134,6 @@ properties:
     description: |-
       Disable the specified displays.
     items:
-      $ref: 'types-1.1.0.yaml#/$defs/disabled'
+      $ref: 'types-1.2.0.yaml#/$defs/disabled'
 
 additionalProperties: false

--- a/schema/ipc-response-1.2.0.yaml
+++ b/schema/ipc-response-1.2.0.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
 
 $schema: https://json-schema.org/draft/2020-12/schema
-$id: https://raw.githubusercontent.com/alex-courtis/way-displays/refs/heads/master/schema/ipc-response-1.1.0.yaml
+$id: https://raw.githubusercontent.com/alex-courtis/way-displays/refs/heads/master/schema/ipc-response-1.2.0.yaml
 
 title: way-displays IPC
 description: |-
@@ -23,23 +23,23 @@ $defs:
           Operation complete, no further data.
 
       CFG:
-        $ref: "cfg-1.1.0.yaml"
+        $ref: "cfg-1.2.0.yaml"
 
       STATE:
         type: object
         properties:
           LID:
-            $ref: "types-1.1.0.yaml#/$defs/lid"
+            $ref: "types-1.2.0.yaml#/$defs/lid"
           HEADS:
             type: array
             items:
-              $ref: "types-1.1.0.yaml#/$defs/head"
+              $ref: "types-1.2.0.yaml#/$defs/head"
         additionalProperties: false
 
       MESSAGES:
         type: array
         items:
-          $ref: "types-1.1.0.yaml#/$defs/ipc_message"
+          $ref: "types-1.2.0.yaml#/$defs/ipc_message"
 
       RC:
         type: integer

--- a/schema/types-1.2.0.yaml
+++ b/schema/types-1.2.0.yaml
@@ -35,8 +35,9 @@ $defs:
         enum:
           - CLOSED
           - OPEN
+          - NOT_PRESENT
         description: |-
-          Subcondition. Evaluates to true if lid is open or closed.
+          Subcondition. Evaluates to true if lid is open, closed or no lid.
     description: |-
       Dynamically evaluated condition.
       Evaluates to true if all its subconditions are also true.

--- a/schema/types-1.2.0.yaml
+++ b/schema/types-1.2.0.yaml
@@ -17,6 +17,7 @@ $defs:
       - Case insensitive mach of name or description e.g. 'ROG PG27AQ'
 
   condition:
+    type: object
     properties:
       PLUGGED:
         type: array
@@ -45,6 +46,7 @@ $defs:
     type: array
     items:
       $ref: '#/$defs/condition'
+    minItems: 1
     description: |-
       A list of conditions. Evaluates to true if at least one of the conditions is true.
 
@@ -75,9 +77,12 @@ $defs:
             $ref: '#/$defs/fuzzy_display_match'
           IF:
             $ref: '#/$defs/condition_list'
+        required:
+          - NAME_DESC
         additionalProperties: false
 
   mode:
+    type: object
     properties:
       NAME_DESC:
         $ref: '#/$defs/fuzzy_display_match'
@@ -97,9 +102,13 @@ $defs:
         type: boolean
         description: |-
           Use the highest available mode.
+    required:
+      - NAME_DESC
+    minProperties: 2
     additionalProperties: false
 
   scale:
+    type: object
     properties:
       NAME_DESC:
         $ref: 'types-1.2.0.yaml#/$defs/fuzzy_display_match'
@@ -107,9 +116,13 @@ $defs:
         type: number
         description: |-
           Scale: float.
+    required:
+      - NAME_DESC
+      - SCALE
     additionalProperties: false
 
   transform:
+    type: object
     properties:
       NAME_DESC:
         $ref: 'types-1.2.0.yaml#/$defs/fuzzy_display_match'
@@ -122,6 +135,9 @@ $defs:
           - FLIPPED-90
           - FLIPPED-180
           - FLIPPED-270
+    required:
+      - NAME_DESC
+      - TRANSFORM
     additionalProperties: false
 
   log_threshold:

--- a/schema/types-1.2.0.yaml
+++ b/schema/types-1.2.0.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
 
 $schema: https://json-schema.org/draft/2020-12/schema
-$id: https://raw.githubusercontent.com/alex-courtis/way-displays/refs/heads/master/schema/types-1.1.0.yaml
+$id: https://raw.githubusercontent.com/alex-courtis/way-displays/refs/heads/master/schema/types-1.2.0.yaml
 
 title: way-displays types
 description: |-
@@ -30,6 +30,12 @@ $defs:
           $ref: '#/$defs/fuzzy_display_match'
         description: |-
           Subcondition. Evaluates to true if all specified displays are currently unplugged.
+      LID:
+        enum:
+          - CLOSED
+          - OPEN
+        description: |-
+          Subcondition. Evaluates to true if lid is open or closed.
     description: |-
       Dynamically evaluated condition.
       Evaluates to true if all its subconditions are also true.
@@ -96,7 +102,7 @@ $defs:
   scale:
     properties:
       NAME_DESC:
-        $ref: 'types-1.1.0.yaml#/$defs/fuzzy_display_match'
+        $ref: 'types-1.2.0.yaml#/$defs/fuzzy_display_match'
       SCALE:
         type: number
         description: |-
@@ -106,7 +112,7 @@ $defs:
   transform:
     properties:
       NAME_DESC:
-        $ref: 'types-1.1.0.yaml#/$defs/fuzzy_display_match'
+        $ref: 'types-1.2.0.yaml#/$defs/fuzzy_display_match'
       TRANSFORM:
         enum:
           - 90

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -687,24 +687,6 @@ static void remove_duplicate_user_transforms(struct Cfg *cfg) {
 	stable_free(by_name_desc);
 }
 
-static void remove_duplicate_disabled(struct Cfg *cfg) {
-	const struct STable *by_name_desc = stable_init(10, 10, false);
-
-	for (struct SList *i = cfg->disabled; i; i = i->nex) {
-		const struct Disabled *disabled = i->val;
-		const struct Disabled *dup = stable_put(by_name_desc, disabled->name_desc, disabled);
-		if (dup) {
-			log_warn("");
-			log_warn("Removing duplicate DISABLED %s", dup->name_desc);
-			cfg_disabled_free(dup);
-		}
-	}
-
-	slist_free(&cfg->disabled);
-	cfg->disabled = stable_vals_slist(by_name_desc);
-	stable_free(by_name_desc);
-}
-
 void validate_fix(struct Cfg *cfg) {
 	if (!cfg) {
 		return;
@@ -736,8 +718,6 @@ void validate_fix(struct Cfg *cfg) {
 	remove_duplicate_user_modes(cfg);
 
 	remove_duplicate_user_transforms(cfg);
-
-	remove_duplicate_disabled(cfg);
 }
 
 static void warn_ambiguous_name_desc_list(struct SList *name_desc, const char * const element) {

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -60,17 +60,17 @@ bool condition_evaluate(const struct Condition *condition) {
 
 	switch (condition->lid) {
 		case LID_CLOSED:
-			if (lid && lid->closed) {
+			if (!lid || !lid->closed) {
 				return false;
 			}
 			break;
 		case LID_OPEN:
-			if (lid && !lid->closed) {
+			if (!lid || lid->closed) {
 				return false;
 			}
 			break;
 		case LID_NOT_PRESENT:
-			if (!lid) {
+			if (lid) {
 				return false;
 			}
 			break;

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -23,6 +23,7 @@ void* condition_clone(const void *data) {
 
 	cloned->plugged = slist_clone(original->plugged, fn_clone_strdup);
 	cloned->unplugged = slist_clone(original->unplugged, fn_clone_strdup);
+	cloned->lid = original->lid;
 
 	return cloned;
 }
@@ -32,7 +33,8 @@ bool condition_equal(const void *a, const void *b) {
 	struct Condition *rhs = (struct Condition*)b;
 
 	return slist_equal(lhs->plugged, rhs->plugged, fn_comp_equals_strcmp) &&
-	       slist_equal(lhs->unplugged, rhs->unplugged, fn_comp_equals_strcmp);
+	       slist_equal(lhs->unplugged, rhs->unplugged, fn_comp_equals_strcmp) &&
+		   lhs->lid == rhs->lid;
 }
 
 bool condition_evaluate(const struct Condition *condition) {

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -3,6 +3,8 @@
 
 #include "conditions.h"
 
+#include "lid.h"
+#include "global.h"
 #include "slist.h"
 #include "fn.h"
 #include "head.h"
@@ -54,6 +56,26 @@ bool condition_evaluate(const struct Condition *condition) {
 		if (slist_find_equal(heads, head_matches_name_desc, name_desc) != NULL) {
 			return false;
 		}
+	}
+
+	switch (condition->lid) {
+		case LID_CLOSED:
+			if (lid && lid->closed) {
+				return false;
+			}
+			break;
+		case LID_OPEN:
+			if (lid && !lid->closed) {
+				return false;
+			}
+			break;
+		case LID_NOT_PRESENT:
+			if (!lid) {
+				return false;
+			}
+			break;
+		default:
+			break;
 	}
 
 	return true;

--- a/src/convert.c
+++ b/src/convert.c
@@ -5,6 +5,7 @@
 #include "convert.h"
 
 #include "cfg.h"
+#include "conditions.h"
 #include "displ.h"
 #include "ipc.h"
 #include "log.h"

--- a/src/convert.c
+++ b/src/convert.c
@@ -104,6 +104,12 @@ static struct NameVal displ_states[] = {
 	{ .val = 0,           .name = NULL,          },
 };
 
+static struct NameVal condition_lids[] = {
+	{ .val = OPEN,   .name = "OPEN",   },
+	{ .val = CLOSED, .name = "CLOSED", },
+	{ .val = 0,      .name = NULL,     },
+};
+
 static struct NameVal scale_round_strategies[] = {
 	{ .val = NEAREST, .name = "NEAREST", },
 	{ .val = UP,      .name = "UP",      },
@@ -274,6 +280,18 @@ enum DisplState displ_state_val(const char *name) {
 
 const char *displ_state_name(enum DisplState displ_state) {
 	return name(displ_states, displ_state);
+}
+
+enum ConditionLid condition_lid_val(const char *name) {
+	return val(condition_lids, name);
+}
+
+const char *condition_lid_name(enum ConditionLid condition_lid) {
+	return name(condition_lids, condition_lid);
+}
+
+char *condition_lid_names(void) {
+	return names(condition_lids);
 }
 
 enum ScaleRoundStrategy scale_round_strategy_val(const char *name) {

--- a/src/convert.c
+++ b/src/convert.c
@@ -106,9 +106,10 @@ static struct NameVal displ_states[] = {
 };
 
 static struct NameVal condition_lids[] = {
-	{ .val = OPEN,   .name = "OPEN",   },
-	{ .val = CLOSED, .name = "CLOSED", },
-	{ .val = 0,      .name = NULL,     },
+	{ .val = LID_OPEN,        .name = "OPEN",        },
+	{ .val = LID_CLOSED,      .name = "CLOSED",      },
+	{ .val = LID_NOT_PRESENT, .name = "NOT_PRESENT", },
+	{ .val = 0,               .name = NULL,          },
 };
 
 static struct NameVal scale_round_strategies[] = {

--- a/src/yaml/marshal-types.c
+++ b/src/yaml/marshal-types.c
@@ -301,6 +301,7 @@ bool yaml_seq_append_condition(const void *data, int sequence) {
 		map &&
 		yaml_map_add_seq("PLUGGED", condition->plugged, yaml_seq_append_str, map) &&
 		yaml_map_add_seq("UNPLUGGED", condition->unplugged, yaml_seq_append_str, map) &&
+		yaml_map_add_enum("LID", condition->lid, condition_lid_name, map) &&
 		yaml_document_append_sequence_item(yaml_document, sequence, map);
 }
 

--- a/src/yaml/unmarshal-types.c
+++ b/src/yaml/unmarshal-types.c
@@ -269,18 +269,23 @@ void *yaml_map_to_condition(const yaml_node_t *map) {
 	if (!table)
 		return NULL;
 
-	const yaml_node_t *seq;
+	const yaml_node_t *node;
 
 	struct Condition *condition = (struct Condition*)calloc(1, sizeof(struct Condition));
 
 	yaml_unmarshal_log_ctx_key("PLUGGED");
-	seq = stable_get(table, "PLUGGED");
-	if (seq && !(condition->plugged = yaml_seq_to_name_desc_list(seq)))
+	node = stable_get(table, "PLUGGED");
+	if (node && !(condition->plugged = yaml_seq_to_name_desc_list(node)))
 		goto err;
 
 	yaml_unmarshal_log_ctx_key("UNPLUGGED");
-	seq = stable_get(table, "UNPLUGGED");
-	if (seq && !(condition->unplugged = yaml_seq_to_name_desc_list(seq)))
+	node = stable_get(table, "UNPLUGGED");
+	if (node && !(condition->unplugged = yaml_seq_to_name_desc_list(node)))
+		goto err;
+
+	yaml_unmarshal_log_ctx_key("LID");
+	node = stable_get(table, "LID");
+	if (node && !(condition->lid = yaml_scalar_to_enum(node, condition_lid_val, condition_lid_names)))
 		goto err;
 
 	goto end;

--- a/src/yaml/unmarshal-types.c
+++ b/src/yaml/unmarshal-types.c
@@ -288,6 +288,9 @@ void *yaml_map_to_condition(const yaml_node_t *map) {
 	if (node && !(condition->lid = yaml_scalar_to_enum(node, condition_lid_val, condition_lid_names)))
 		goto err;
 
+	if (!condition->plugged && !condition->unplugged && !condition->lid)
+		goto err;
+
 	goto end;
 
 err:

--- a/tst/cfg/validate-fix-disabled.log
+++ b/tst/cfg/validate-fix-disabled.log
@@ -1,3 +1,0 @@
-
-Removing duplicate DISABLED dup
-

--- a/tst/tst-cfg.c
+++ b/tst/tst-cfg.c
@@ -245,26 +245,35 @@ void merge_set__adaptive_sync_off(void **state) {
 void merge_set__disabled(void **state) {
 	struct State *s = *state;
 
-	struct Disabled *disabled = calloc(1, sizeof(struct Disabled));
-	disabled->name_desc = strdup("cond");
+	struct Disabled *disabled1 = calloc(1, sizeof(struct Disabled));
+	disabled1->name_desc = strdup("cond");
 	struct Condition *cond = calloc(1, sizeof(struct Condition));
 	slist_append(&cond->plugged, strdup("display"));
-	slist_append(&disabled->conditions, cond);
+	slist_append(&disabled1->conditions, cond);
 	cond = calloc(1, sizeof(struct Condition));
 	cond->lid = LID_NOT_PRESENT;
-	slist_append(&disabled->conditions, cond);
+	slist_append(&disabled1->conditions, cond);
+
+	struct Disabled *disabled2 = calloc(1, sizeof(struct Disabled));
+	disabled2->name_desc = strdup("twelve");
+
+	cond = calloc(1, sizeof(struct Condition));
+	slist_append(&cond->plugged, strdup("FOUR"));
+	slist_append(&disabled1->conditions, cond);
 
 	slist_append(&s->to->disabled, cfg_disabled_always("to"));
 	slist_append(&s->to->disabled, cfg_disabled_always("both"));
 
 	slist_append(&s->from->disabled, cfg_disabled_always("from"));
 	slist_append(&s->from->disabled, cfg_disabled_always("both"));
-	slist_append(&s->from->disabled, cfg_disabled_clone(disabled));
+	slist_append(&s->from->disabled, cfg_disabled_clone(disabled1));
+	slist_append(&s->from->disabled, cfg_disabled_clone(disabled2));
 
 	slist_append(&s->expected->disabled, cfg_disabled_always("to"));
 	slist_append(&s->expected->disabled, cfg_disabled_always("both"));
 	slist_append(&s->expected->disabled, cfg_disabled_always("from"));
-	slist_append(&s->expected->disabled, disabled);
+	slist_append(&s->expected->disabled, disabled1);
+	slist_append(&s->expected->disabled, disabled2);
 
 	struct Cfg *merged = merge_set(s->to, s->from);
 
@@ -594,27 +603,6 @@ void validate_fix__user_transform(void **state) {
 	free(expected_log);
 }
 
-void validate_fix__disabled(void **state) {
-	struct State *s = *state;
-
-	slist_append(&s->from->disabled, cfg_disabled_always("one"));
-	slist_append(&s->from->disabled, cfg_disabled_always("dup"));
-	slist_append(&s->from->disabled, cfg_disabled_always("dup"));
-
-	validate_fix(s->from);
-
-	char *expected_log = read_file("tst/cfg/validate-fix-disabled.log");
-	assert_log(WARNING, expected_log);
-	assert_logs_empty();
-
-	slist_append(&s->expected->disabled, cfg_disabled_always("one"));
-	slist_append(&s->expected->disabled, cfg_disabled_always("dup"));
-
-	assert_cfg_equal(s->from, s->expected);
-
-	free(expected_log);
-}
-
 void validate_warn__(void **state) {
 	struct State *s = *state;
 
@@ -697,7 +685,6 @@ int main(void) {
 		TEST(validate_fix__user_scale),
 		TEST(validate_fix__user_mode),
 		TEST(validate_fix__user_transform),
-		TEST(validate_fix__disabled),
 
 		TEST(validate_warn__),
 	};

--- a/tst/tst-cfg.c
+++ b/tst/tst-cfg.c
@@ -250,6 +250,9 @@ void merge_set__disabled(void **state) {
 	struct Condition *cond = calloc(1, sizeof(struct Condition));
 	slist_append(&cond->plugged, strdup("display"));
 	slist_append(&disabled->conditions, cond);
+	cond = calloc(1, sizeof(struct Condition));
+	cond->lid = LID_NOT_PRESENT;
+	slist_append(&disabled->conditions, cond);
 
 	slist_append(&s->to->disabled, cfg_disabled_always("to"));
 	slist_append(&s->to->disabled, cfg_disabled_always("both"));

--- a/tst/tst-conditions.c
+++ b/tst/tst-conditions.c
@@ -13,7 +13,6 @@
 
 struct State {
 	struct Condition *condition;
-	struct SList *conditions;
 };
 
 static int before_all(void **state) {
@@ -50,7 +49,6 @@ static int after_each(void **state) {
 	struct State *s = *state;
 
 	condition_free(s->condition);
-	slist_free_vals(&s->conditions, condition_free);
 	slist_free_vals(&heads, head_free);
 
 	free(lid);

--- a/tst/tst-conditions.c
+++ b/tst/tst-conditions.c
@@ -1,11 +1,14 @@
 #include "tst.h"
 
 #include <cmocka.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "conditions.h"
+#include "global.h"
 #include "head.h"
+#include "lid.h"
 #include "slist.h"
 
 struct State {
@@ -13,15 +16,15 @@ struct State {
 	struct SList *conditions;
 };
 
-int before_all(void **state) {
+static int before_all(void **state) {
 	return 0;
 }
 
-int after_all(void **state) {
+static int after_all(void **state) {
 	return 0;
 }
 
-int before_each(void **state) {
+static int before_each(void **state) {
 	struct State *s = calloc(1, sizeof(struct State));
 	s->condition = calloc(1, sizeof(struct Condition));
 
@@ -37,16 +40,21 @@ int before_each(void **state) {
 	slist_append(&heads, h2);
 	slist_append(&heads, h3);
 
+	lid = NULL;
+
 	*state = s;
 	return 0;
 }
 
-int after_each(void **state) {
+static int after_each(void **state) {
 	struct State *s = *state;
 
 	condition_free(s->condition);
 	slist_free_vals(&s->conditions, condition_free);
 	slist_free_vals(&heads, head_free);
+
+	free(lid);
+	lid = NULL;
 
 	free(s);
 
@@ -54,7 +62,7 @@ int after_each(void **state) {
 }
 
 
-void conditions__plugged(void **state) {
+static void conditions__plugged(void **state) {
 	struct State *s = *state;
 
 	slist_append(&s->condition->plugged, strdup("DP-1"));
@@ -70,7 +78,7 @@ void conditions__plugged(void **state) {
 	assert_false(condition_evaluate(s->condition));
 }
 
-void conditions__unplugged(void **state) {
+static void conditions__unplugged(void **state) {
 	struct State *s = *state;
 
 	slist_append(&s->condition->unplugged, strdup("DP-4"));
@@ -80,7 +88,37 @@ void conditions__unplugged(void **state) {
 	assert_false(condition_evaluate(s->condition));
 }
 
-void conditions__complex(void **state) {
+static void conditions__lid_closed(void **state) {
+	struct State *s = *state;
+
+	s->condition->lid = LID_CLOSED;
+
+	lid = calloc(1, sizeof(struct Lid));
+	lid->closed = true;
+
+	assert_false(condition_evaluate(s->condition));
+}
+
+static void conditions__lid_open(void **state) {
+	struct State *s = *state;
+
+	s->condition->lid = LID_OPEN;
+
+	lid = calloc(1, sizeof(struct Lid));
+	lid->closed = false;
+
+	assert_false(condition_evaluate(s->condition));
+}
+
+static void conditions__lid_not_present(void **state) {
+	struct State *s = *state;
+
+	s->condition->lid = LID_NOT_PRESENT;
+
+	assert_false(condition_evaluate(s->condition));
+}
+
+static void conditions__complex(void **state) {
 	struct State *s = *state;
 
 	slist_append(&s->condition->plugged, strdup("DP-1"));
@@ -88,12 +126,21 @@ void conditions__complex(void **state) {
 
 	slist_append(&s->condition->unplugged, strdup("DP-4"));
 	assert_true(condition_evaluate(s->condition));
+
+	s->condition->lid = LID_CLOSED;
+	lid = calloc(1, sizeof(struct Lid));
+	lid->closed = false;
+
+	assert_true(condition_evaluate(s->condition));
 }
 
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		TEST(conditions__plugged),
 		TEST(conditions__unplugged),
+		TEST(conditions__lid_closed),
+		TEST(conditions__lid_open),
+		TEST(conditions__lid_not_present),
 		TEST(conditions__complex),
 	};
 

--- a/tst/tst-conditions.c
+++ b/tst/tst-conditions.c
@@ -94,7 +94,7 @@ static void conditions__lid_closed(void **state) {
 	lid = calloc(1, sizeof(struct Lid));
 	lid->closed = true;
 
-	assert_false(condition_evaluate(s->condition));
+	assert_true(condition_evaluate(s->condition));
 }
 
 static void conditions__lid_open(void **state) {
@@ -105,7 +105,7 @@ static void conditions__lid_open(void **state) {
 	lid = calloc(1, sizeof(struct Lid));
 	lid->closed = false;
 
-	assert_false(condition_evaluate(s->condition));
+	assert_true(condition_evaluate(s->condition));
 }
 
 static void conditions__lid_not_present(void **state) {
@@ -113,7 +113,7 @@ static void conditions__lid_not_present(void **state) {
 
 	s->condition->lid = LID_NOT_PRESENT;
 
-	assert_false(condition_evaluate(s->condition));
+	assert_true(condition_evaluate(s->condition));
 }
 
 static void conditions__complex(void **state) {
@@ -127,7 +127,7 @@ static void conditions__complex(void **state) {
 
 	s->condition->lid = LID_CLOSED;
 	lid = calloc(1, sizeof(struct Lid));
-	lid->closed = false;
+	lid->closed = true;
 
 	assert_true(condition_evaluate(s->condition));
 }

--- a/tst/tst-yaml-unmarshal.c
+++ b/tst/tst-yaml-unmarshal.c
@@ -162,6 +162,15 @@ static void yaml_root_to_cfg__disabled(void **state) {
 
 	slist_append(&expected->disabled, disabled);
 
+	disabled = calloc(1, sizeof(struct Disabled));
+	disabled->name_desc = strdup("twelve");
+
+	cond = calloc(1, sizeof(struct Condition));
+	slist_append(&cond->plugged, strdup("FOUR"));
+	slist_append(&disabled->conditions, cond);
+
+	slist_append(&expected->disabled, disabled);
+
 	slist_append(&expected->disabled, cfg_disabled_always("BAD_DISABLED_IFS"));
 	slist_append(&expected->disabled, cfg_disabled_always("MISTYPED_IF_SCALAR"));
 	slist_append(&expected->disabled, cfg_disabled_always("MISTYPED_IF_MAP"));

--- a/tst/tst-yaml-unmarshal.c
+++ b/tst/tst-yaml-unmarshal.c
@@ -168,6 +168,7 @@ static void yaml_root_to_cfg__disabled(void **state) {
 	slist_append(&expected->disabled, cfg_disabled_always("MISTYPED_UN_PLUGGED_SCALAR"));
 	slist_append(&expected->disabled, cfg_disabled_always("MISTYPED_UN_PLUGGED_MAP"));
 	slist_append(&expected->disabled, cfg_disabled_always("MISTYPED_LID_MAP"));
+	slist_append(&expected->disabled, cfg_disabled_always("NO_VALID_CONDITIONS"));
 
 	check_unmarshalled_cfg("tst/yaml/cfg-disabled.yaml", expected, "tst/yaml/cfg-disabled.log");
 }

--- a/tst/tst-yaml-unmarshal.c
+++ b/tst/tst-yaml-unmarshal.c
@@ -167,6 +167,7 @@ static void yaml_root_to_cfg__disabled(void **state) {
 	slist_append(&expected->disabled, cfg_disabled_always("MISTYPED_IF_MAP"));
 	slist_append(&expected->disabled, cfg_disabled_always("MISTYPED_UN_PLUGGED_SCALAR"));
 	slist_append(&expected->disabled, cfg_disabled_always("MISTYPED_UN_PLUGGED_MAP"));
+	slist_append(&expected->disabled, cfg_disabled_always("MISTYPED_LID_MAP"));
 
 	check_unmarshalled_cfg("tst/yaml/cfg-disabled.yaml", expected, "tst/yaml/cfg-disabled.log");
 }

--- a/tst/yaml/cfg-all.yaml
+++ b/tst/yaml/cfg-all.yaml
@@ -46,4 +46,5 @@ DISABLED:
     - TWO
   - UNPLUGGED:
     - THREE
+  - LID: CLOSED
 

--- a/tst/yaml/cfg-disabled.log
+++ b/tst/yaml/cfg-disabled.log
@@ -9,6 +9,7 @@ Ignoring invalid DISABLED MISTYPED_UN_PLUGGED_SCALAR PLUGGED expected sequence, 
 Ignoring invalid DISABLED MISTYPED_UN_PLUGGED_SCALAR UNPLUGGED expected sequence, got scalar
 Ignoring invalid DISABLED MISTYPED_UN_PLUGGED_MAP PLUGGED expected sequence, got map
 Ignoring invalid DISABLED MISTYPED_UN_PLUGGED_MAP UNPLUGGED expected sequence, got map
+Ignoring invalid DISABLED MISTYPED_LID_MAP LID expected scalar, got sequence, valid values: OPEN|CLOSED
 Ignoring invalid DISABLED expected scalar or map, got sequence
 DISABLED: Ignoring missing NAME_DESC
 

--- a/tst/yaml/cfg-disabled.log
+++ b/tst/yaml/cfg-disabled.log
@@ -9,7 +9,7 @@ Ignoring invalid DISABLED MISTYPED_UN_PLUGGED_SCALAR PLUGGED expected sequence, 
 Ignoring invalid DISABLED MISTYPED_UN_PLUGGED_SCALAR UNPLUGGED expected sequence, got scalar
 Ignoring invalid DISABLED MISTYPED_UN_PLUGGED_MAP PLUGGED expected sequence, got map
 Ignoring invalid DISABLED MISTYPED_UN_PLUGGED_MAP UNPLUGGED expected sequence, got map
-Ignoring invalid DISABLED MISTYPED_LID_MAP LID expected scalar, got sequence, valid values: OPEN|CLOSED
+Ignoring invalid DISABLED MISTYPED_LID_MAP LID expected scalar, got sequence, valid values: OPEN|CLOSED|NOT_PRESENT
 Ignoring invalid DISABLED expected scalar or map, got sequence
 DISABLED: Ignoring missing NAME_DESC
 

--- a/tst/yaml/cfg-disabled.yaml
+++ b/tst/yaml/cfg-disabled.yaml
@@ -9,6 +9,10 @@ DISABLED:
           - TWO
       - UNPLUGGED:
           - THREE
+  - NAME_DESC: twelve
+    IF:
+      - PLUGGED:
+          - FOUR
   - '!(disabled1'
   - NAME_DESC: '!(disabled2'
   - NAME_DESC: BAD_DISABLED_IFS

--- a/tst/yaml/cfg-disabled.yaml
+++ b/tst/yaml/cfg-disabled.yaml
@@ -34,6 +34,10 @@ DISABLED:
           FOO: bar
       - UNPLUGGED:
           FOO: bar
+  - NAME_DESC: MISTYPED_LID_MAP
+    IF:
+      - LID:
+        -
   - -
     -
 

--- a/tst/yaml/cfg-disabled.yaml
+++ b/tst/yaml/cfg-disabled.yaml
@@ -38,6 +38,9 @@ DISABLED:
     IF:
       - LID:
         -
+  - NAME_DESC: NO_VALID_CONDITIONS
+    IF:
+      - FOO: bar
   - -
     -
 

--- a/tst/yaml/cfg-invalid.log
+++ b/tst/yaml/cfg-invalid.log
@@ -25,4 +25,5 @@ Ignoring invalid DISABLED regex '(disabled1':  Unmatched ( or \(
 Ignoring invalid DISABLED regex '(disabled2':  Unmatched ( or \(
 Ignoring invalid DISABLED regex '(plugged1':  Unmatched ( or \(
 Ignoring invalid DISABLED regex '(unplugged1':  Unmatched ( or \(
+Ignoring invalid DISABLED BAD_DISABLED_IFS LID BAD_DISABLED_LID, valid values: OPEN|CLOSED
 

--- a/tst/yaml/cfg-invalid.log
+++ b/tst/yaml/cfg-invalid.log
@@ -25,5 +25,5 @@ Ignoring invalid DISABLED regex '(disabled1':  Unmatched ( or \(
 Ignoring invalid DISABLED regex '(disabled2':  Unmatched ( or \(
 Ignoring invalid DISABLED regex '(plugged1':  Unmatched ( or \(
 Ignoring invalid DISABLED regex '(unplugged1':  Unmatched ( or \(
-Ignoring invalid DISABLED BAD_DISABLED_IFS LID BAD_DISABLED_LID, valid values: OPEN|CLOSED
+Ignoring invalid DISABLED BAD_DISABLED_IFS LID BAD_DISABLED_LID, valid values: OPEN|CLOSED|NOT_PRESENT
 

--- a/tst/yaml/cfg-invalid.yaml
+++ b/tst/yaml/cfg-invalid.yaml
@@ -45,3 +45,4 @@ DISABLED:
           - '!(plugged1'
       - UNPLUGGED:
           - '!(unplugged1'
+      - LID: BAD_DISABLED_LID

--- a/tst/yaml/data.c
+++ b/tst/yaml/data.c
@@ -75,7 +75,7 @@ struct Cfg *cfg_all(void) {
 	slist_append(&disabled->conditions, cond);
 
 	cond = calloc(1, sizeof(struct Condition));
-	cond->lid = CLOSED;
+	cond->lid = LID_CLOSED;
 	slist_append(&disabled->conditions, cond);
 
 	slist_append(&cfg->disabled, disabled);

--- a/tst/yaml/data.c
+++ b/tst/yaml/data.c
@@ -74,6 +74,10 @@ struct Cfg *cfg_all(void) {
 	slist_append(&cond->unplugged, strdup("THREE"));
 	slist_append(&disabled->conditions, cond);
 
+	cond = calloc(1, sizeof(struct Condition));
+	cond->lid = CLOSED;
+	slist_append(&disabled->conditions, cond);
+
 	slist_append(&cfg->disabled, disabled);
 
 	slist_append(&cfg->user_transforms, cfg_user_transform_init("twelve", WL_OUTPUT_TRANSFORM_FLIPPED));

--- a/tst/yaml/ipc-request-cfg-invalid.yaml
+++ b/tst/yaml/ipc-request-cfg-invalid.yaml
@@ -47,3 +47,4 @@ CFG:
             - '!(plugged1'
         - UNPLUGGED:
             - '!(unplugged1'
+        - LID: BAD_DISABLED_LID

--- a/tst/yaml/ipc-request-cfg-set.yaml
+++ b/tst/yaml/ipc-request-cfg-set.yaml
@@ -49,4 +49,5 @@ CFG:
       - TWO
     - UNPLUGGED:
       - THREE
+    - LID: CLOSED
 

--- a/tst/yaml/ipc-responses-map.yaml
+++ b/tst/yaml/ipc-responses-map.yaml
@@ -48,6 +48,7 @@ CFG:
       - TWO
     - UNPLUGGED:
       - THREE
+    - LID: CLOSED
 STATE:
   LID:
     CLOSED: TRUE

--- a/tst/yaml/ipc-responses-seq.yaml
+++ b/tst/yaml/ipc-responses-seq.yaml
@@ -48,6 +48,7 @@
         - TWO
       - UNPLUGGED:
         - THREE
+      - LID: CLOSED
   STATE:
     LID:
       CLOSED: TRUE


### PR DESCRIPTION
fixes #114

I'd me most grateful for your review of this feature @mrsobakin , notably from the logical perspective.

I migrated from yaml-cpp to libyaml following the most recent ABI break.

Adds new condition:
```yaml
      LID:
        enum:
          - CLOSED
          - OPEN
          - NOT_PRESENT
        description: |-
          Subcondition. Evaluates to true if lid is open, closed or no lid.
```

example:
```yaml
## Disable the specified displays.
## Resulting state of a display is equal to OR of all matching conditions, so
## explicit disabled without `IF` will override any conditions for the display.
## In this example:
##  HDMI-1 will always be disabled
##  eDP-1 will be disabled only if both DP-1 and DP-2 are plugged.
##  DP-3 will be disabled when the lid is open or HDMI-2 is plugged
DISABLED:
  - 'HDMI-1'
  - NAME_DESC: 'eDP-1'
    IF:
      - PLUGGED:
          - '!^DP-1$'
          - '!^DP-2$'
  - NAME_DESC: 'DP-3'
    IF:
      - LID: OPEN
  - NAME_DESC: 'DP-3'
    IF:
      - PLUGGED:
          - 'HDMI-2'
```